### PR TITLE
added option to disable http content type checking for each plugin

### DIFF
--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/plugins/DetailedPlugin.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/plugins/DetailedPlugin.java
@@ -17,6 +17,7 @@ public class DetailedPlugin {
     private String author;
     private int spigotId;
     private int bukkitId;
+    private boolean ignoreContentType;
     private String customLink;
 
     public DetailedPlugin(String installationPath, String name, String version, String author, int spigotId, int bukkitId, String customLink) {
@@ -83,6 +84,14 @@ public class DetailedPlugin {
 
     public void setBukkitId(int bukkitId) {
         this.bukkitId = bukkitId;
+    }
+
+    public boolean getIgnoreContentType() {
+        return ignoreContentType;
+    }
+
+    public void setIgnoreContentType(boolean ignoreContentType) {
+        this.ignoreContentType = ignoreContentType;
     }
 
     public String getCustomLink() {

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/plugins/TaskPluginsUpdater.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/plugins/TaskPluginsUpdater.java
@@ -117,6 +117,7 @@ public class TaskPluginsUpdater extends BetterThread {
                     DYModule spigotId = pluginsConfig.put(name, plName, "spigot-id").setDefValues("0");
                     //DYModule songodaId = new DYModule(config, getModules(), name, plName,+".songoda-id", 0); // TODO WORK_IN_PROGRESS
                     DYModule bukkitId = pluginsConfig.put(name, plName, "bukkit-id").setDefValues("0");
+                    DYModule ignoreContentType = pluginsConfig.put(name, plName, "ignore-ContentType").setDefValues("false");
                     DYModule customCheckURL = pluginsConfig.put(name, plName, "custom-check-url");
                     DYModule customDownloadURL = pluginsConfig.put(name, plName, "custom-download-url");
 
@@ -129,6 +130,7 @@ public class TaskPluginsUpdater extends BetterThread {
                     // Update the detailed plugins in-memory values
                     pl.setSpigotId(spigotId.asInt());
                     pl.setBukkitId(bukkitId.asInt());
+                    pl.setIgnoreContentType(ignoreContentType.asBoolean());
                     pl.setCustomLink(customDownloadURL.asString());
 
                     // Check for missing author in plugin.yml
@@ -434,13 +436,13 @@ public class TaskPluginsUpdater extends BetterThread {
                     if (!pl.isPremium()) {
                         if (userProfile.equals(manualProfile)) {
                             File cache_dest = new File(GD.WORKING_DIR + "/autoplug/downloads/" + pl.getName() + "[" + latest + "].jar");
-                            TaskPluginDownload task = new TaskPluginDownload("PluginDownloader", getManager(), pl.getName(), latest, url, userProfile, cache_dest);
+                            TaskPluginDownload task = new TaskPluginDownload("PluginDownloader", getManager(), pl.getName(), latest, url, pl.getIgnoreContentType(), userProfile, cache_dest);
                             downloadTasksList.add(task);
                             task.start();
                         } else {
                             File oldPl = new File(pl.getInstallationPath());
                             File dest = new File(GD.WORKING_DIR + "/plugins/" + pl.getName() + "-LATEST-" + "[" + latest + "]" + ".jar");
-                            TaskPluginDownload task = new TaskPluginDownload("PluginDownloader", getManager(), pl.getName(), latest, url, userProfile, dest, oldPl);
+                            TaskPluginDownload task = new TaskPluginDownload("PluginDownloader", getManager(), pl.getName(), latest, url, pl.getIgnoreContentType(), userProfile, dest, oldPl);
                             downloadTasksList.add(task);
                             task.start();
                         }


### PR DESCRIPTION
# Added option to disable http content-type checking for each plugin

This PR adds a new option to the *plugins-config.yml* which allows a user to disable the checks on HTTP content type headers.

This can be relevant if the hoster of the pluginfile sets the header incorrectly, as described in #91


## Implementation

- A configuration value has been added.
- A new boolean attribute is added to the *DetailedPlugin* class to store the value from the configuration along with the setter and getter methods
- the value is passed to the downloader task, when it is created
- when checking the server response, the value is checked before the content subtype is evaluated


## Open questions:

The new option only affects the content type **subtype**, not the content type itself. This should not be relevant, in my opinion.

I added a new overload to the *TaskPluginDownload* class. But maybe it would be better to clean up all the calls to the constructor, so that fewer overrides are needed.

