### PR TITLE
Replace all 'autoplug.online's with 'autoplug.one'

### DIFF
--- a/src/main/java/com/osiris/autoplug/client/configs/GeneralConfig.java
+++ b/src/main/java/com/osiris/autoplug/client/configs/GeneralConfig.java
@@ -52,7 +52,7 @@ public class GeneralConfig extends DreamYaml {
 
 
         server_key = put(name, "server", "key").setDefValues("INSERT_KEY_HERE").setComments(
-                "Enter your Server-Key here. You get it by registering yourself and your server on https://autoplug.online.\n" +
+                "Enter your Server-Key here. You get it by registering yourself and your server on https://autoplug.one.\n" +
                         "The Server-Key enables remote access from your account.\n" +
                         "No matter what, keep this key private to ensure your servers security!");
 

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/TaskDownload.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/TaskDownload.java
@@ -66,7 +66,7 @@ public class TaskDownload extends BetterThread {
         AL.debug(this.getClass(), "Downloading " + fileName + " from: " + url);
 
         Request request = new Request.Builder().url(url)
-                .header("User-Agent", "AutoPlug Client/" + new Random().nextInt() + " - https://autoplug.online")
+                .header("User-Agent", "AutoPlug Client/" + new Random().nextInt() + " - https://autoplug.one")
                 .build();
 
         Response response = new OkHttpClient.Builder().followRedirects(true).build().newCall(request).execute();

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/java/TaskJavaDownload.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/java/TaskJavaDownload.java
@@ -63,7 +63,7 @@ public class TaskJavaDownload extends BetterThread {
         AL.debug(this.getClass(), "Downloading " + fileName + " from: " + url);
 
         Request request = new Request.Builder().url(url)
-                .header("User-Agent", "AutoPlug Client/" + new Random().nextInt() + " - https://autoplug.online")
+                .header("User-Agent", "AutoPlug Client/" + new Random().nextInt() + " - https://autoplug.one")
                 .build();
         Response response = new OkHttpClient().newCall(request).execute();
         ResponseBody body = null;

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/plugins/TaskPluginDownload.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/plugins/TaskPluginDownload.java
@@ -126,7 +126,7 @@ public class TaskPluginDownload extends BetterThread {
         AL.debug(this.getClass(), "Downloading " + fileName + " from: " + url);
 
         Request request = new Request.Builder().url(url)
-                .header("User-Agent", "AutoPlug Client/" + new Random().nextInt() + " - https://autoplug.online")
+                .header("User-Agent", "AutoPlug Client/" + new Random().nextInt() + " - https://autoplug.one")
                 .build();
 
         Response response = new OkHttpClient().newCall(request).execute();

--- a/src/test/java/com/osiris/autoplug/client/managers/UtilsWebClientTest.java
+++ b/src/test/java/com/osiris/autoplug/client/managers/UtilsWebClientTest.java
@@ -25,7 +25,7 @@ class UtilsWebClientTest {
     @Test
     void test() {
         WebClient client = UtilsWebClient.getNewCustomClient(30000, 10000,
-                UtilsWebClient.buildUniqueUserAgent()); //"AutoPlug Client/"+new Random().nextInt()+" - https://autoplug.online"
+                UtilsWebClient.buildUniqueUserAgent()); //"AutoPlug Client/"+new Random().nextInt()+" - https://autoplug.one"
 
         String testUrl1 = "https://www.spigotmc.org/resources/unlimited-enchants.82329/download?version=348662";
         String testUrl2 = "https://www.spigotmc.org/resources/rankmeup-gui-based-rankup-plugin-1-8-1-16.81464/download?version=348659";


### PR DESCRIPTION
Replaces all old 'autoplug.online' website references with the new 'autoplug.one' domain