### PR TITLE
Changed AdoptOpenJDK and OpenJDK references to Eclipse Adoptium

### DIFF
--- a/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
+++ b/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
@@ -98,7 +98,7 @@ public class UpdaterConfig extends DreamYaml {
                 "Note that this won't update your already existing Java installation, but instead create a new one inside of /autoplug/system/jre, which then will be used to run your server."
         );
         java_updater_version = put(name, "java-updater", "version").setDefValues("16").setComments(
-                "The major Java version. List of versions available: https://api.adoptopenjdk.net/v3/info/available_releases",
+                "The major Java version. List of versions available: https://api.adoptium.net/v3/info/available_releases",
                 "Note: If you change this, also remove the \"build-id\" value to guarantee correct update-detection."
         );
         java_updater_build_id = put(name, "java-updater", "build-id").setComments(

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/java/AdoptV3API.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/java/AdoptV3API.java
@@ -17,31 +17,29 @@ import com.osiris.autoplug.core.json.exceptions.WrongJsonTypeException;
 import java.io.IOException;
 
 /**
- * Details here: https://api.adoptopenjdk.net/q/swagger-ui
+ * Details here: https://api.adoptium.net/q/swagger-ui
  */
 public class AdoptV3API {
-    private static final String START_DOWNLOAD_URL = "https://api.adoptopenjdk.net/v3/binary/version/";
-    private static final String START_RELEASES_URL = "https://api.adoptopenjdk.net/v3/info/release_versions?architecture=";
-    private static final String START_ASSETS_URL = "https://api.adoptopenjdk.net/v3/assets/version/";
+    private static final String START_DOWNLOAD_URL = "https://api.adoptium.net/v3/binary/version/";
+    private static final String START_RELEASES_URL = "https://api.adoptium.net/v3/info/release_versions?architecture=";
+    private static final String START_ASSETS_URL = "https://api.adoptium.net/v3/assets/version/";
 
     /**
      * Creates and returns a new url from the provided parameters. <br>
-     * For a list of all available parameters types see: https://api.adoptopenjdk.net/q/swagger-ui/#/Assets/searchReleasesByVersion
+     * For a list of all available parameters types see: https://api.adoptium.net/q/swagger-ui/#/Assets/searchReleasesByVersion
      *
      * @param releaseVersionName Example: 11.0.4.1+11.1
      * @param isLargeHeapSize    If true allows your jvm to use more that 57gb of ram.
      * @param isHotspotImpl      If true uses hotspot, otherwise the openj9 implementation.
      * @param isOnlyLTS          If true only shows LTS (Long Term Support) releases.
      * @param maxItems           Example: 20
-     * @param isOpenJDKVendor    If true uses the default OpenJDK vendor instead of AdoptOpenJDK.
      * @return
      */
     public String getVersionInformationUrl(String releaseVersionName, OperatingSystemArchitectureType osArchitectureType, boolean isLargeHeapSize, ImageType imageType,
                                            boolean isHotspotImpl, boolean isOnlyLTS, OperatingSystemType osType, int maxItems,
-                                           boolean isOpenJDKVendor, VendorProjectType vendorProject, ReleaseType releaseType) {
+                                           VendorProjectType vendorProject, ReleaseType releaseType) {
         String jvmImplementation = isHotspotImpl ? "hotspot" : "openj9";
         String heapSize = isLargeHeapSize ? "large" : "normal";
-        String vendor = isOpenJDKVendor ? "openjdk" : "adoptopenjdk";
         return START_ASSETS_URL
                 + releaseVersionName
                 + "?architecture=" + osArchitectureType.name
@@ -55,35 +53,33 @@ public class AdoptV3API {
                 + "&project=" + vendorProject.name
                 + "&release_type=" + releaseType.name
                 + "&sort_method=DEFAULT&sort_order=DESC"
-                + "&vendor=" + vendor;
+                + "&vendor=eclipse";
     }
 
     public JsonArray getVersionInformation(String releaseVersionName, OperatingSystemArchitectureType osArchitectureType, boolean isLargeHeapSize, ImageType imageType,
                                            boolean isHotspotImpl, boolean isOnlyLTS, OperatingSystemType osType, int maxItems,
-                                           boolean isOpenJDKVendor, VendorProjectType vendorProject, ReleaseType releaseType) throws WrongJsonTypeException, IOException, HttpErrorException {
+                                           VendorProjectType vendorProject, ReleaseType releaseType) throws WrongJsonTypeException, IOException, HttpErrorException {
         return new JsonTools().getJsonArray(getVersionInformationUrl(
                 releaseVersionName, osArchitectureType, isLargeHeapSize, imageType, isHotspotImpl,
-                isOnlyLTS, osType, maxItems, isOpenJDKVendor, vendorProject, releaseType
+                isOnlyLTS, osType, maxItems, vendorProject, releaseType
         ));
     }
 
     /**
      * Creates and returns a new url from the provided parameters. <br>
-     * For a list of all available parameters types see: https://api.adoptopenjdk.net/q/swagger-ui/#/Release%20Info/getReleaseVersions
+     * For a list of all available parameters types see: https://api.adoptium.net/q/swagger-ui/#/Release%20Info/getReleaseVersions
      *
      * @param isLargeHeapSize If true allows your jvm to use more that 57gb of ram.
      * @param isHotspotImpl   If true uses hotspot, otherwise the openj9 implementation.
      * @param isOnlyLTS       If true only shows LTS (Long Term Support) releases.
      * @param maxItems        Example: 20
-     * @param isOpenJDKVendor If true uses the default OpenJDK vendor instead of AdoptOpenJDK.
      * @return
      */
     public String getReleasesUrl(OperatingSystemArchitectureType osArchitectureType, boolean isLargeHeapSize, ImageType imageType,
                                  boolean isHotspotImpl, boolean isOnlyLTS, OperatingSystemType osType, int maxItems,
-                                 boolean isOpenJDKVendor, VendorProjectType vendorProject, ReleaseType releaseType) {
+                                 VendorProjectType vendorProject, ReleaseType releaseType) {
         String jvmImplementation = isHotspotImpl ? "hotspot" : "openj9";
         String heapSize = isLargeHeapSize ? "large" : "normal";
-        String vendor = isOpenJDKVendor ? "openjdk" : "adoptopenjdk";
         return START_RELEASES_URL
                 + osArchitectureType.name
                 + "&heap_size=" + heapSize
@@ -96,31 +92,29 @@ public class AdoptV3API {
                 + "&project=" + vendorProject.name
                 + "&release_type=" + releaseType.name
                 + "&sort_method=DEFAULT&sort_order=DESC"
-                + "&vendor=" + vendor;
+                + "&vendor=eclipse";
     }
 
     public JsonObject getReleases(OperatingSystemArchitectureType osArchitectureType, boolean isLargeHeapSize, ImageType imageType,
                                   boolean isHotspotImpl, boolean isOnlyLTS, OperatingSystemType osType, int maxItems,
-                                  boolean isOpenJDKVendor, VendorProjectType vendorProject, ReleaseType releaseType) throws WrongJsonTypeException, IOException, HttpErrorException {
+                                  VendorProjectType vendorProject, ReleaseType releaseType) throws WrongJsonTypeException, IOException, HttpErrorException {
         return new JsonTools().getJsonObject(getReleasesUrl(osArchitectureType, isLargeHeapSize, imageType,
-                isHotspotImpl, isOnlyLTS, osType, maxItems, isOpenJDKVendor, vendorProject, releaseType));
+                isHotspotImpl, isOnlyLTS, osType, maxItems, vendorProject, releaseType));
     }
 
     /**
      * Creates and returns a new url from the provided parameters. <br>
-     * For a list of all available parameters types see: https://api.adoptopenjdk.net/q/swagger-ui/#/Binary/getBinaryByVersion
+     * For a list of all available parameters types see: https://api.adoptium.net/q/swagger-ui/#/Binary/getBinaryByVersion
      *
      * @param releaseName     Note that this is not the regular version name. Example: jdk-15.0.2+7
      * @param isHotspotImpl   If true uses hotspot, otherwise the openj9 implementation.
      * @param isLargeHeapSize If true allows your jvm to use more that 57gb of ram.
-     * @param isOpenJDKVendor If true uses the default OpenJDK vendor instead of AdoptOpenJDK.
      */
     public String getDownloadUrl(String releaseName, OperatingSystemType osType, OperatingSystemArchitectureType osArchitectureType,
-                                 ImageType imageType, boolean isHotspotImpl, boolean isLargeHeapSize, boolean isOpenJDKVendor,
+                                 ImageType imageType, boolean isHotspotImpl, boolean isLargeHeapSize,
                                  VendorProjectType vendorProject) {
         String jvmImplementation = isHotspotImpl ? "hotspot" : "openj9";
         String heapSize = isLargeHeapSize ? "large" : "normal";
-        String vendor = isOpenJDKVendor ? "openjdk" : "adoptopenjdk";
         return START_DOWNLOAD_URL
                 + releaseName + "/"
                 + osType.name + "/"
@@ -128,7 +122,7 @@ public class AdoptV3API {
                 + imageType.name + "/"
                 + jvmImplementation + "/"
                 + heapSize + "/"
-                + vendor + "?project=" + vendorProject.name;
+                + "eclipse?project=" + vendorProject.name;
     }
 
 
@@ -178,7 +172,9 @@ public class AdoptV3API {
         AMD64("x64"),
         X86_64("x64"),
         // x32 with alternative names:
-        I386("x32");
+        I386("x32"),
+        // AARCHx64 with alternative names:
+        ARM64("aarch64");
 
         private final String name;
 

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/java/TaskJavaDownload.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/java/TaskJavaDownload.java
@@ -91,7 +91,7 @@ public class TaskJavaDownload extends BetterThread {
                 fileName = fileName.replace(".file", ".tar.gz");
             } else {
                 // In this case we check the response header for file information
-                // Example: (content-disposition, attachment; filename=OpenJDK15U-jre_x86-32_windows_hotspot_15.0.2_7.zip)
+                // Example: (content-disposition, attachment; filename=JDK15U-jre_x86-32_windows_hotspot_15.0.2_7.zip)
                 String contentDispo = response.headers().get("content-disposition");
                 if (contentDispo == null)
                     throw new Exception("Failed to determine download file type!");

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/java/TaskJavaUpdater.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/java/TaskJavaUpdater.java
@@ -118,7 +118,6 @@ public class TaskJavaUpdater extends BetterThread {
                 false,
                 osType,
                 50,
-                false, // Use adopt jdk instead, because other vendors are not supported by this search somehow
                 AdoptV3API.VendorProjectType.JDK,
                 AdoptV3API.ReleaseType.GENERAL_AVAILABILITY
         );
@@ -154,7 +153,6 @@ public class TaskJavaUpdater extends BetterThread {
                 false,
                 osType,
                 50,
-                false, // Use adopt jdk instead, because other vendors are not supported by this search somehow
                 AdoptV3API.VendorProjectType.JDK,
                 AdoptV3API.ReleaseType.GENERAL_AVAILABILITY);
 
@@ -170,7 +168,6 @@ public class TaskJavaUpdater extends BetterThread {
                 imageType,
                 true,
                 isLargeHeapSize,
-                false, // Use adopt jdk instead, because other vendors are not supported by this search somehow
                 AdoptV3API.VendorProjectType.JDK
         );
 


### PR DESCRIPTION
Resolves Osiris-Team/AutoPlug-Client#103

removed "isOpenJDKVender" variables from API functions since Adoptium only accepts "eclipse"
added "ARM64 = AARCH64" to OSArchitectureType list