### PR TITLE
Update MCServerUpdater to 2.7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
         <dependency>
             <groupId>me.hsgamer</groupId>
             <artifactId>mc-server-updater-lib</artifactId>
-            <version>2.7.1</version>
+            <version>2.7.2</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
         <dependency>
             <groupId>me.hsgamer</groupId>
             <artifactId>mc-server-updater-lib</artifactId>
-            <version>2.7.2</version>
+            <version>2.7.3</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Now the `build version` can be set to `default` or `latest` to use the `default version`.

Paper, Purpur, Spigot (why?), Fabric and Sponge updaters will fetch the latest version from their APIs.
Others will use their hard-coded version.

Will close #112 if not consider the github api and jenkins api (too much chaos to have a unified API).