### PR TITLE
Update Zip4J to 2.11.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 **/.idea/
 **/*.iml
 
+# Visual Studio Code
+**/.vscode/
+
 # MacOS
 .DS_Store
 

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>net.lingala.zip4j</groupId>
             <artifactId>zip4j</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.3</version>
         </dependency>
         <!-- Needed for working with .tar.gz files, in the Java-Updater -->
         <dependency>


### PR DESCRIPTION
Update Zip4J from 2.10.0 to 2.11.3 in POM.xml per NIST CVE-2023-22899 [[Link](https://nvd.nist.gov/vuln/detail/CVE-2023-22899)] via Docker [[Link](https://dso.docker.com/cve/CVE-2023-22899)]