### PR TITLE
update MCServerUpdater to 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
         <dependency>
             <groupId>me.hsgamer</groupId>
             <artifactId>mc-server-updater-lib</artifactId>
-            <version>2.9.2</version>
+            <version>3.2.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
There were a lot of changes on the supported projects [here](https://www.spigotmc.org/resources/mcserverupdater.98003/)

This is probably the last time I work on this. I lost interests in the library and spent most on my standalone CLI app that is used privately.
Therefore, I will no longer go here and update the library.