### PR TITLE
Add option to not overwrite Modrinth and CurseForge ID to the mods config

### DIFF
--- a/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
+++ b/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
@@ -62,6 +62,7 @@ public class UpdaterConfig extends MyYaml {
     public YamlSection mods_updater_version;
     public YamlSection mods_updater_async;
     public YamlSection mods_update_check_name_for_mod_loader;
+    public YamlSection mods_update_update_id_from_jar ;
 
 
     public UpdaterConfig() throws IOException, DuplicateKeyException, YamlReaderException, IllegalListException, NotLoadedException, IllegalKeyException, YamlWriterException {
@@ -224,6 +225,9 @@ public class UpdaterConfig extends MyYaml {
         mods_update_check_name_for_mod_loader = put(name, "mods-updater", "check-name-for-mod-loader").setDefValues("false").setComments(
                 "Only relevant for determining if a curseforge mod release is forge or fabric.",
                 "If enabled additionally checks the mod name to see if it contains fabric or forge.");
+        mods_update_update_id_from_jar = put(name, "mods-updater", "update-id-from-jar").setDefValues("true").setComments(
+                "Gets the mod id from the jar file and updates the id in the mods-config.",
+                "Disable this if the mod id in the jar file is not the same as the modrinth id.");
 
         save();
         unlockFile();

--- a/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
+++ b/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
@@ -62,7 +62,6 @@ public class UpdaterConfig extends MyYaml {
     public YamlSection mods_updater_version;
     public YamlSection mods_updater_async;
     public YamlSection mods_update_check_name_for_mod_loader;
-    public YamlSection mods_update_update_id_from_jar ;
 
 
     public UpdaterConfig() throws IOException, DuplicateKeyException, YamlReaderException, IllegalListException, NotLoadedException, IllegalKeyException, YamlWriterException {
@@ -225,9 +224,6 @@ public class UpdaterConfig extends MyYaml {
         mods_update_check_name_for_mod_loader = put(name, "mods-updater", "check-name-for-mod-loader").setDefValues("false").setComments(
                 "Only relevant for determining if a curseforge mod release is forge or fabric.",
                 "If enabled additionally checks the mod name to see if it contains fabric or forge.");
-        mods_update_update_id_from_jar = put(name, "mods-updater", "update-id-from-jar").setDefValues("true").setComments(
-                "Gets the mod id from the jar file and updates the id in the mods-config.",
-                "Disable this if the mod id in the jar file is not the same as the modrinth id.");
 
         save();
         unlockFile();

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/TaskModsUpdater.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/TaskModsUpdater.java
@@ -105,13 +105,13 @@ public class TaskModsUpdater extends BThread {
                 YamlSection jenkinsArtifactName = modsConfig.put(name, plName, "alternatives", "jenkins", "artifact-name");
                 YamlSection jenkinsBuildId = modsConfig.put(name, plName, "alternatives", "jenkins", "build-id").setDefValues("0");
 
-                if (updaterConfig.mods_update_update_id_from_jar.asBoolean()) {
-                    if (installedMod.modrinthId != null) modrinthId.setValues(installedMod.modrinthId);
-                    if (installedMod.curseforgeId != null) curseforgeId.setValues(installedMod.curseforgeId);
-                }
+                if (installedMod.modrinthId != null && modrinthId.asString() == null)
+                    modrinthId.setValues(installedMod.modrinthId);
+                if (installedMod.curseforgeId != null && curseforgeId.asString() == null)
+                    curseforgeId.setValues(installedMod.curseforgeId);
 
                 // Update the detailed mods in-memory values
-                installedMod.modrinthId = modrinthId.asString();
+                installedMod.modrinthId = (modrinthId.asString());
                 installedMod.curseforgeId = (curseforgeId.asString());
                 installedMod.ignoreContentType = (ignoreContentType.asBoolean());
                 installedMod.forceLatest = (forceLatest.asBoolean());
@@ -233,8 +233,8 @@ public class TaskModsUpdater extends BThread {
                 String type = result.getDownloadType(); // The file type to download (Note: When 'external' is returned nothing will be downloaded. Working on a fix for this!)
                 String latest = result.getLatestVersion(); // The latest version as String
                 String downloadUrl = result.getDownloadUrl(); // The download url for the latest version
-                String resultmodrinthId = result.getSpigotId();
-                String resultBukkitId = result.getBukkitId();
+                String resultModrinthId = mod.modrinthId;
+                String resultCurseForgeId = mod.curseforgeId;
                 this.setStatus("Checked '" + mod.getName() + "' mod (" + results.size() + "/" + includedSize + ")");
                 if (code == 0 || code == 1) {
                     doDownloadLogic(mod, result);
@@ -249,15 +249,13 @@ public class TaskModsUpdater extends BThread {
                     getWarnings().add(new BWarning(this, new Exception("Unknown error occurred! Code: " + code + "."), "Notify the developers. Fastest way is through discord (https://discord.gg/GGNmtCC)."));
 
                 try {
-                    YamlSection mmodrinthId = modsConfig.get(modsConfigName, mod.getName(), "modrinth-id");
-                    if (resultmodrinthId != null
-                            && (mmodrinthId.asString() == null || mmodrinthId.asInt() == 0)) // Because we can get a "null" string from the server
-                        mmodrinthId.setValues(resultmodrinthId);
+                    YamlSection mModrinthId = modsConfig.get(modsConfigName, mod.getName(), "modrinth-id");
+                    if (resultModrinthId != null && mModrinthId.asString() == null) // Because we can get a "null" string from the server
+                        mModrinthId.setValues(resultModrinthId);
 
-                    YamlSection mBukkitId = modsConfig.get(modsConfigName, mod.getName(), "bukkit-id");
-                    if (resultBukkitId != null
-                            && (mmodrinthId.asString() == null || mmodrinthId.asInt() == 0)) // Because we can get a "null" string from the server
-                        mBukkitId.setValues(resultBukkitId);
+                    YamlSection mCurseForgeId = modsConfig.get(modsConfigName, mod.getName(), "curseforge-id");
+                    if (resultCurseForgeId != null && mCurseForgeId.asString() == null) // Because we can get a "null" string from the server
+                        mCurseForgeId.setValues(resultCurseForgeId);
 
                     // The config gets saved at the end of the runAtStart method.
                 } catch (Exception e) {
@@ -290,13 +288,6 @@ public class TaskModsUpdater extends BThread {
                 }
                 if (matchingResult == null)
                     throw new Exception("This should not happen! Please report to the devs!");
-
-                if (updaterConfig.mods_update_update_id_from_jar.asBoolean()) {
-                    if (download.mod.modrinthId != null)
-                        modsConfig.put(modsConfigName, download.mod.getName(), "modrinth-id").setValues(download.mod.modrinthId);
-                    if (download.mod.curseforgeId != null)
-                        modsConfig.put(modsConfigName, download.mod.getName(), "curseforge-id").setValues(download.mod.curseforgeId);
-                }
 
                 if (download.isDownloadSuccessful())
                     matchingResult.setResultCode((byte) 5);

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/TaskModsUpdater.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/TaskModsUpdater.java
@@ -105,8 +105,10 @@ public class TaskModsUpdater extends BThread {
                 YamlSection jenkinsArtifactName = modsConfig.put(name, plName, "alternatives", "jenkins", "artifact-name");
                 YamlSection jenkinsBuildId = modsConfig.put(name, plName, "alternatives", "jenkins", "build-id").setDefValues("0");
 
-                if (installedMod.modrinthId != null) modrinthId.setValues(installedMod.modrinthId);
-                if (installedMod.curseforgeId != null) curseforgeId.setValues(installedMod.curseforgeId);
+                if (updaterConfig.mods_update_update_id_from_jar.asBoolean()) {
+                    if (installedMod.modrinthId != null) modrinthId.setValues(installedMod.modrinthId);
+                    if (installedMod.curseforgeId != null) curseforgeId.setValues(installedMod.curseforgeId);
+                }
 
                 // Update the detailed mods in-memory values
                 installedMod.modrinthId = modrinthId.asString();
@@ -289,10 +291,12 @@ public class TaskModsUpdater extends BThread {
                 if (matchingResult == null)
                     throw new Exception("This should not happen! Please report to the devs!");
 
-                if (download.mod.modrinthId != null)
-                    modsConfig.put(modsConfigName, download.mod.getName(), "modrinth-id").setValues(download.mod.modrinthId);
-                if (download.mod.curseforgeId != null)
-                    modsConfig.put(modsConfigName, download.mod.getName(), "modrinth-id").setValues(download.mod.curseforgeId);
+                if (updaterConfig.mods_update_update_id_from_jar.asBoolean()) {
+                    if (download.mod.modrinthId != null)
+                        modsConfig.put(modsConfigName, download.mod.getName(), "modrinth-id").setValues(download.mod.modrinthId);
+                    if (download.mod.curseforgeId != null)
+                        modsConfig.put(modsConfigName, download.mod.getName(), "curseforge-id").setValues(download.mod.curseforgeId);
+                }
 
                 if (download.isDownloadSuccessful())
                     matchingResult.setResultCode((byte) 5);


### PR DESCRIPTION
When updating Geyser, the Modrinth ID found in the `.jar` is `geyser-fabric` although, the ID on Modrinth is just `geyser`. This results in AutoPlug changing the ID in the `mods.yml` from `geyser` to `geyser-fabric` which fails the update since this is not a valid Modrinth mod ID. To solve this, I've added an `update-id-from-jar` option to the `mods.yml` configuration that, when it's set to `true`, will not overwrite the ID in the `mods.yml` file with the ID from the `.jar`. I've defaulted this to `false` so there's no change to current users but users can disable this functionality if wanted.