### PR TITLE
Update BackupConfig.java

### DIFF
--- a/src/main/java/com/osiris/autoplug/client/configs/BackupConfig.java
+++ b/src/main/java/com/osiris/autoplug/client/configs/BackupConfig.java
@@ -77,7 +77,7 @@ public class BackupConfig extends MyYaml {
                 "Where to create your backups.");
         backup_include = put(name, "include", "enable").setDefValues("true").setComments(
                 "Add specific files or folders you want to include in the backup, to the list below.",
-                "Windows/Linux formats are supported. './' stands for the servers root directory.",
+                "Windows/Linux formats are supported. './' stands for the servers root directory."
         );
         backup_include_list = put(name, "include", "list").setDefValues("./").setComments(
                 "  - ./example/directory",

--- a/src/main/java/com/osiris/autoplug/client/configs/BackupConfig.java
+++ b/src/main/java/com/osiris/autoplug/client/configs/BackupConfig.java
@@ -75,15 +75,14 @@ public class BackupConfig extends MyYaml {
         );
         backup_path = put(name, "path").setDefValues("./autoplug/backups").setComments(
                 "Where to create your backups.");
-        backup_include = put(name, "include", "enable").setDefValues("false").setComments(
+        backup_include = put(name, "include", "enable").setDefValues("true").setComments(
                 "Add specific files or folders you want to include in the backup, to the list below.",
-                "Windows/Linux formats are supported. './' stands for the servers root directory."
+                "Windows/Linux formats are supported. './' stands for the servers root directory.",
         );
-        backup_include_list = put(name, "include", "list").setDefValues(
-                "./",
-                "./example/directory",
-                "./specific-file.txt",
-                "C:\\Users\\Example Windows Directory"
+        backup_include_list = put(name, "include", "list").setDefValues("./").setComments(
+                "  - ./example/directory",
+                "  - ./specific-file.txt",
+                "  - C:\\Users\\Example Windows Directory"
         );
         backup_exclude = put(name, "exclude", "enable").setDefValues("true").setComments(
                 "Add specific files or folders you want to exclude from the backup, to the list below.",

--- a/src/main/java/com/osiris/autoplug/client/configs/BackupConfig.java
+++ b/src/main/java/com/osiris/autoplug/client/configs/BackupConfig.java
@@ -79,7 +79,10 @@ public class BackupConfig extends MyYaml {
                 "Add specific files or folders you want to include in the backup, to the list below.",
                 "Windows/Linux formats are supported. './' stands for the servers root directory."
         );
-        backup_include_list = put(name, "include", "list").setDefValues("./").setComments(
+        backup_include_list = put(name, "include", "list").setDefValues(
+                "./",
+                "./server.properties"
+        ).setComments(
                 "  - ./example/directory",
                 "  - ./specific-file.txt",
                 "  - C:\\Users\\Example Windows Directory"

--- a/src/main/java/com/osiris/autoplug/client/configs/BackupConfig.java
+++ b/src/main/java/com/osiris/autoplug/client/configs/BackupConfig.java
@@ -75,7 +75,7 @@ public class BackupConfig extends MyYaml {
         );
         backup_path = put(name, "path").setDefValues("./autoplug/backups").setComments(
                 "Where to create your backups.");
-        backup_include = put(name, "include", "enable").setDefValues("true").setComments(
+        backup_include = put(name, "include", "enable").setDefValues("false").setComments(
                 "Add specific files or folders you want to include in the backup, to the list below.",
                 "Windows/Linux formats are supported. './' stands for the servers root directory."
         );


### PR DESCRIPTION
including sample files / folders should have been set to `false` by default

```yml
backup: 
  include: 
    # Add specific files or folders you want to include in the backup, to the list below.
    # Windows/Linux formats are supported. './' stands for the servers root directory.
    enable: false
```