### PR TITLE
Removed annoying no-command enter message

### DIFF
--- a/src/main/java/com/osiris/autoplug/client/console/Commands.java
+++ b/src/main/java/com/osiris/autoplug/client/console/Commands.java
@@ -64,11 +64,13 @@ public final class Commands {
             Objects.requireNonNull(command);
             command = command.trim();
             first = Character.toString(command.charAt(0));
+        } catch (StringIndexOutOfBoundsException e) {
+            return false;
         } catch (Exception e) {
             AL.warn("Failed to read command '" + command + "'! Enter .help for all available commands!", e);
             return false;
         }
-
+        
         if (first.equals(".")) {
             try {
                 if (command.equals(".help") || command.equals(".h")) {


### PR DESCRIPTION
Added additional catch for `String index out of range: 0` exception, to prevent AP from throwing a warning every time you press enter without typing a command into the console.

Failed to read command ''! Enter .help for all available commands! Details: String index out of range: 0