### PR TITLE
Fix fatal SSH starting error & correct comment

### DIFF
--- a/src/main/java/com/osiris/autoplug/client/configs/SSHConfig.java
+++ b/src/main/java/com/osiris/autoplug/client/configs/SSHConfig.java
@@ -10,8 +10,6 @@ package com.osiris.autoplug.client.configs;
 
 import java.io.IOException;
 
-import org.jline.utils.OSUtils;
-
 import com.osiris.autoplug.client.tasks.SSHManager;
 import com.osiris.dyml.Yaml;
 import com.osiris.dyml.YamlSection;

--- a/src/main/java/com/osiris/autoplug/client/configs/SSHConfig.java
+++ b/src/main/java/com/osiris/autoplug/client/configs/SSHConfig.java
@@ -91,7 +91,7 @@ public class SSHConfig extends MyYaml {
                 "The generated file will be a .pub file, which contains the public key.",
                 "Example connection command: `ssh -i /path/to/private/key username@server-ip-address`");
         
-        server_private_key = put("server-private-key")
+        server_private_key = put(name, "server-private-key")
             .setComments(
                 "The private key used by the server to authenticate itself to the SSH console.",
                 "The file must be in the OpenSSH format.",

--- a/src/main/java/com/osiris/autoplug/client/configs/SSHConfig.java
+++ b/src/main/java/com/osiris/autoplug/client/configs/SSHConfig.java
@@ -93,8 +93,6 @@ public class SSHConfig extends MyYaml {
                 "The generated file will be a .pub file, which contains the public key.",
                 "Example connection command: `ssh -i /path/to/private/key username@server-ip-address`");
         
-
-        String sshPath = OSUtils.IS_WINDOWS ? "%USERPROFILE%\\.ssh\\id_rsa" : "~/.ssh/id_rsa";
         server_private_key = put("server-private-key")
             .setComments(
                 "The private key used by the server to authenticate itself to the SSH console.",
@@ -105,7 +103,7 @@ public class SSHConfig extends MyYaml {
                 "In the same directory as the private key, there will also need to be a file with the same name and a .pub extension, which contains the public key.",
                 "NOTICE: The .ssh directory is not present by default, and must be created via the usage of the 'ssh-keygen' command.",
                 "Example:",
-                "server-private-key: " + sshPath);
+                "server-private-key: ./autoplug/id_rsa");
 
         username = put(name, "username").setDefValues("autoplug")
             .setComments(


### PR DESCRIPTION
Fixed a fatal starting error that occurred when obtaining the example server-private-key value. this was removed for another reason, instead of being fixed: using the system SSH rsa key could be considered bad practice due to the insecurities of using the same key twice. in the event someone (maybe by the web gui) gets the key, that same key can be used as a system console assuming SSH was enabled on the host machine.