### PR TITLE
Bump mc-server-lib to version 3.7.0 and update 'software' key comments in UpdaterConfig.java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@ AUTO-GENERATED FILE, CHANGES SHOULD BE DONE IN ./JPM.java or ./src/main/java/JPM
         <dependency>
             <groupId>me.hsgamer</groupId>
             <artifactId>mc-server-updater-lib</artifactId>
-            <version>3.4.0</version>
+            <version>3.7.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
+++ b/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
@@ -149,8 +149,9 @@ public class UpdaterConfig extends MyYaml {
                 "The actual content/file will update though, thus rename it to something like server.jar, and do not include version info to prevent confusion.");
         server_software = put(name, "server-updater", "software").setDefValues("paper").setComments(
                 "Select your favorite server software. Enter the name below. Supported software:\n" +
-                        "- Minecraft (paper, waterfall, travertine, velocity, purpur, fabric," +
-                        "spigot, bungeecord, patina, pufferfish, mirai, pearl, windspigot)\n" +
+                        "- Minecraft (paper, travertine, waterfall, velocity, folia, pandaspigot, purpur, bungeecord, " +
+                        "spigot, patina, pufferfish, fabric, fabric-dev, spongevanilla, spongevanilla-recommended, " +
+			"spongeforge, spongeforge-recommended, mohist, plazma, kaiiju, divine, leaf, leaves, luminol)\n" +
                         "- Any Steam game (enter the app-id below, go to https://steamdb.info/ and search for: \"<game-name> server\" to find the app-id)\n" +
                         "Note: If you change this, also reset the \"build-id\" to 0 to guarantee correct update-detection.");
         server_steamcmd_login = put(name, "server-updater", "steam-cmd-login")


### PR DESCRIPTION
This PR/commit bumps the mc-server-lib library to version 3.7.0 which adds support for updating PandaSpigot and Mohist. There were some removed server software and some added ones in the previous release. The comments of the 'software' key in the UpdaterConfig.java have also been updated accordingly to the up-to-date supported updaters and are now in the order as it is in the UpdateBuilder.java file of the MCServerUpdater project. A little space was also missing in the comments (which caused a space to miss after a comma), this has also been fixed accordingly.