### PR TITLE
Add Steam Workshop updates for DayZ mods

### DIFF
--- a/src/main/java/com/osiris/autoplug/client/configs/ModsConfig.java
+++ b/src/main/java/com/osiris/autoplug/client/configs/ModsConfig.java
@@ -44,6 +44,7 @@ public class ModsConfig extends MyYaml {
                         "If there are mods that weren't found by the search-algorithm, you can add an id (spigot or bukkit) and a custom link (optional & must be a static link to the latest mod jar).\n" +
                         "modrinth-id: Is the 'Project-ID' and can be found on the mods modrinth site inside of the 'About' box, under 'Technical Information' at the bottom left.\n" +
                         "curseforge-id: Is also called 'Project-ID' and can be found on the mods curseforge site inside of the 'About' box at the right.\n" +
+                        "steam-workshop-id: Is read from meta.cpp for supported Steam Workshop mods and updated through SteamCMD.\n" +
                         "ignore-content-type: If true, does not check if the downloaded file is of type jar or zip, and downloads it anyway.\n" +
                         "force-latest: If true, does not search for updates compatible with this Minecraft version and simply picks the latest release.\n" +
                         "force-update: If true, downloads the update every time even if its already on the latest version.\n" +

--- a/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
+++ b/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
@@ -63,6 +63,7 @@ public class UpdaterConfig extends MyYaml {
     public YamlSection mods_updater_path;
     public YamlSection mods_updater_version;
     public YamlSection mods_updater_async;
+    public YamlSection mods_updater_steam_workshop_app_id;
     public YamlSection mods_update_check_name_for_mod_loader;
 
 
@@ -227,6 +228,9 @@ public class UpdaterConfig extends MyYaml {
                 "Asynchronously checks for updates.",
                 "Normally this should be faster than checking for updates synchronously, thus it should be enabled.",
                 "The only downside of this is that your log file gets a bit messy.");
+        mods_updater_steam_workshop_app_id = put(name, "mods-updater", "steam-workshop-app-id").setDefValues("221100").setComments(
+                "Steam app-id used for Steam Workshop mod downloads. DayZ Workshop mods use 221100.",
+                "Only used for mod directories that contain a meta.cpp file with a publishedid.");
         mods_update_check_name_for_mod_loader = put(name, "mods-updater", "check-name-for-mod-loader").setDefValues("false").setComments(
                 "Only relevant for determining if a curseforge mod release is forge or fabric.",
                 "If enabled additionally checks the mod name to see if it contains fabric or forge.");

--- a/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
+++ b/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
@@ -245,6 +245,7 @@ public class UpdaterConfig extends MyYaml {
         String jP = java_updater_profile.asString();
         String sP = server_updater_profile.asString();
         String uP = plugins_updater_profile.asString();
+        String mP = mods_updater_profile.asString();
 
         if (!selfP.equals("NOTIFY") && !selfP.equals("MANUAL") && !selfP.equals("AUTOMATIC")) {
             String correction = self_updater_profile.getDefValue().asString();
@@ -268,6 +269,12 @@ public class UpdaterConfig extends MyYaml {
             String correction = plugins_updater_profile.getDefValue().asString();
             AL.warn("Config error -> " + plugins_updater_profile.getKeys() + " must be: NOTIFY or MANUAL or AUTOMATIC. Applied default!");
             plugins_updater_profile.setValues(correction);
+        }
+
+        if (!mP.equals("NOTIFY") && !mP.equals("MANUAL") && !mP.equals("AUTOMATIC")) {
+            String correction = mods_updater_profile.getDefValue().asString();
+            AL.warn("Config error -> " + mods_updater_profile.getKeys() + " must be: NOTIFY or MANUAL or AUTOMATIC. Applied default!");
+            mods_updater_profile.setValues(correction);
         }
         return this;
     }

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/ModDownloadTask.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/ModDownloadTask.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 Osiris-Team.
+ * All rights reserved.
+ *
+ * This software is copyrighted work, licensed under the terms
+ * of the MIT-License. Consult the "LICENSE" file for details.
+ */
+
+package com.osiris.autoplug.client.tasks.updater.mods;
+
+import com.osiris.autoplug.client.tasks.updater.search.SearchResult;
+
+interface ModDownloadTask {
+    void start();
+
+    boolean isAlive();
+
+    String getPlName();
+
+    SearchResult getSearchResult();
+
+    boolean isDownloadSuccessful();
+
+    boolean isInstallSuccessful();
+}

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/SteamWorkshopMod.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/SteamWorkshopMod.java
@@ -26,7 +26,7 @@ public class SteamWorkshopMod extends MinecraftMod {
     private final String timestamp;
 
     public SteamWorkshopMod(File directory, String name, String publishedId, String timestamp) {
-        super(directory.getAbsolutePath(), name, timestamp != null ? timestamp : publishedId, "Steam Workshop", null, null, null);
+        super(directory.getAbsolutePath(), name, null, "Steam Workshop", null, null, null);
         this.directory = directory;
         this.publishedId = publishedId;
         this.timestamp = timestamp;

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/SteamWorkshopMod.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/SteamWorkshopMod.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2024 Osiris-Team.
+ * All rights reserved.
+ *
+ * This software is copyrighted work, licensed under the terms
+ * of the MIT-License. Consult the "LICENSE" file for details.
+ */
+
+package com.osiris.autoplug.client.tasks.updater.mods;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+public class SteamWorkshopMod extends MinecraftMod {
+    private final File directory;
+    private String publishedId;
+    private final String timestamp;
+
+    public SteamWorkshopMod(File directory, String name, String publishedId, String timestamp) {
+        super(directory.getAbsolutePath(), name, timestamp != null ? timestamp : publishedId, "Steam Workshop", null, null, null);
+        this.directory = directory;
+        this.publishedId = publishedId;
+        this.timestamp = timestamp;
+    }
+
+    public File getDirectory() {
+        return directory;
+    }
+
+    public String getPublishedId() {
+        return publishedId;
+    }
+
+    public void setPublishedId(String publishedId) {
+        this.publishedId = publishedId;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    @NotNull
+    public static List<SteamWorkshopMod> findIn(File dir) throws IOException {
+        if (!dir.exists()) throw new FileNotFoundException("Directory does not exist: " + dir);
+
+        List<SteamWorkshopMod> mods = new ArrayList<>();
+        File[] files = dir.listFiles();
+        if (files == null) return mods;
+
+        Arrays.sort(files, Comparator.comparing(File::getName));
+        for (File file : files) {
+            if (!file.isDirectory()) continue;
+
+            File metaFile = new File(file, "meta.cpp");
+            if (metaFile.exists())
+                mods.add(readFromMeta(file, metaFile));
+        }
+        return mods;
+    }
+
+    static SteamWorkshopMod readFromMeta(File modDir, File metaFile) throws IOException {
+        String name = modDir.getName();
+        String publishedId = null;
+        String timestamp = null;
+
+        for (String line : Files.readAllLines(metaFile.toPath(), StandardCharsets.UTF_8)) {
+            String trimmedLine = line.trim();
+            if (trimmedLine.isEmpty() || trimmedLine.startsWith("//")) continue;
+
+            int equalsIndex = trimmedLine.indexOf('=');
+            if (equalsIndex < 0) continue;
+
+            String key = trimmedLine.substring(0, equalsIndex).trim();
+            String value = trimmedLine.substring(equalsIndex + 1).trim();
+            int semicolonIndex = value.indexOf(';');
+            if (semicolonIndex >= 0)
+                value = value.substring(0, semicolonIndex).trim();
+            if (value.startsWith("\"") && value.endsWith("\"") && value.length() >= 2)
+                value = value.substring(1, value.length() - 1);
+
+            if (key.equals("name")) name = value;
+            else if (key.equals("publishedid")) publishedId = value;
+            else if (key.equals("timestamp")) timestamp = value;
+        }
+
+        if (publishedId == null || !publishedId.matches("\\d+"))
+            throw new IOException("Failed to read publishedid from " + metaFile);
+
+        return new SteamWorkshopMod(modDir, name, publishedId, timestamp);
+    }
+}

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/TaskModDownload.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/TaskModDownload.java
@@ -25,7 +25,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 
 
-public class TaskModDownload extends BThread {
+public class TaskModDownload extends BThread implements ModDownloadTask {
     private final String plName;
     private final String plLatestVersion;
     private final String url;
@@ -205,6 +205,10 @@ public class TaskModDownload extends BThread {
 
     public File getDownloadDest() {
         return dest;
+    }
+
+    public SearchResult getSearchResult() {
+        return searchResult;
     }
 
     public boolean isDownloadSuccessful() {

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/TaskModsUpdater.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/TaskModsUpdater.java
@@ -15,6 +15,7 @@ import com.osiris.autoplug.client.managers.FileManager;
 import com.osiris.autoplug.client.tasks.updater.plugins.ResourceFinder;
 import com.osiris.autoplug.client.tasks.updater.search.SearchResult;
 import com.osiris.autoplug.client.utils.GD;
+import com.osiris.autoplug.client.utils.SteamCMD;
 import com.osiris.autoplug.client.utils.UtilsFile;
 import com.osiris.autoplug.client.utils.UtilsMinecraft;
 import com.osiris.betterthread.BThread;
@@ -40,7 +41,7 @@ public class TaskModsUpdater extends BThread {
     private final String manualProfile = "MANUAL";
     private final String automaticProfile = "AUTOMATIC";
     private final int updatesDownloaded = 0;
-    private final List<TaskModDownload> downloadTasksList = new ArrayList<>();
+    private final List<ModDownloadTask> downloadTasksList = new ArrayList<>();
     @NotNull
     private final List<MinecraftMod> includedMods = new ArrayList<>();
     @NotNull
@@ -81,7 +82,9 @@ public class TaskModsUpdater extends BThread {
         setStatus("Fetching latest mod data...");
 
         userProfile = updaterConfig.mods_updater_profile.asString();
-        this.allMods.addAll(new UtilsMinecraft().getMods(FileManager.convertRelativeToAbsolutePath(updaterConfig.mods_updater_path.asString())));
+        File modsDir = FileManager.convertRelativeToAbsolutePath(updaterConfig.mods_updater_path.asString());
+        this.allMods.addAll(new UtilsMinecraft().getMods(modsDir));
+        this.allMods.addAll(SteamWorkshopMod.findIn(modsDir));
 
         for (MinecraftMod installedMod :
                 allMods) {
@@ -96,6 +99,7 @@ public class TaskModsUpdater extends BThread {
                 YamlSection author = modsConfig.put(name, plName, "author").setDefValues(installedMod.getAuthor());
                 YamlSection modrinthId = modsConfig.put(name, plName, "modrinth-id");
                 YamlSection curseforgeId = modsConfig.put(name, plName, "curseforge-id");
+                YamlSection steamWorkshopId = modsConfig.put(name, plName, "steam-workshop-id");
                 YamlSection ignoreContentType = modsConfig.put(name, plName, "ignore-content-type").setDefValues("false");
                 YamlSection forceLatest = modsConfig.put(name, plName, "force-latest").setDefValues("false");
                 YamlSection forceUpdate = modsConfig.put(name, plName, "force-update").setDefValues("false");
@@ -111,6 +115,8 @@ public class TaskModsUpdater extends BThread {
                     modrinthId.setValues(installedMod.modrinthId);
                 if (installedMod.curseforgeId != null && curseforgeId.asString() == null)
                     curseforgeId.setValues(installedMod.curseforgeId);
+                if (installedMod instanceof SteamWorkshopMod && steamWorkshopId.asString() == null)
+                    steamWorkshopId.setValues(((SteamWorkshopMod) installedMod).getPublishedId());
 
                 // Update the detailed mods in-memory values
                 installedMod.modrinthId = (modrinthId.asString());
@@ -125,6 +131,15 @@ public class TaskModsUpdater extends BThread {
                 installedMod.jenkinsArtifactName = (jenkinsArtifactName.asString());
                 installedMod.jenkinsBuildId = (jenkinsBuildId.asInt());
                 installedMod.forceUpdate = forceUpdate.asBoolean();
+                if (installedMod instanceof SteamWorkshopMod) {
+                    ((SteamWorkshopMod) installedMod).setPublishedId(steamWorkshopId.asString());
+                    installedMod.setVersion(version.asString());
+                    if (exclude.asBoolean())
+                        excludedMods.add(installedMod);
+                    else
+                        includedMods.add(installedMod);
+                    continue;
+                }
 
                 // Check for missing author in internal config
                 if ((installedMod.getVersion() == null)
@@ -184,10 +199,11 @@ public class TaskModsUpdater extends BThread {
         int sizeBukkitMods = 0;
         int sizeUnknownMods = 0;
         int sizeCustomMods = 0;
+        int sizeSteamWorkshopMods = 0;
 
 
         String mcVersion = updaterConfig.mods_updater_version.asString();
-        if (mcVersion == null) updaterConfig.server_updater_version.asString();
+        if (mcVersion == null) mcVersion = updaterConfig.server_updater_version.asString();
         if (mcVersion == null) mcVersion = Server.getMCVersion();
 
         ExecutorService executorService;
@@ -201,7 +217,10 @@ public class TaskModsUpdater extends BThread {
                 includedMods) {
             try {
                 setStatus("Initialising update check for  " + mod.getName() + "...");
-                if (mod.customCheckURL != null) { // Custom Check
+                if (mod instanceof SteamWorkshopMod) {
+                    sizeSteamWorkshopMods++;
+                    activeFutures.add(executorService.submit(() -> findSteamWorkshopUpdate((SteamWorkshopMod) mod)));
+                } else if (mod.customCheckURL != null) { // Custom Check
                     sizeCustomMods++;
                     activeFutures.add(executorService.submit(() -> new ResourceFinder().findByCustomCheckURL(mod)));
                 } else if (mod.jenkinsProjectUrl != null) { // JENKINS MOD
@@ -220,6 +239,7 @@ public class TaskModsUpdater extends BThread {
                 this.getWarnings().add(new BWarning(this, e, "Critical error while searching for update for '" + mod.getName() + "' mod!"));
             }
         }
+        executorService.shutdown();
 
         List<SearchResult> results = new ArrayList<>();
         while (!activeFutures.isEmpty()) {
@@ -276,8 +296,8 @@ public class TaskModsUpdater extends BThread {
         // Wait until all download tasks have finished.
         while (!downloadTasksList.isEmpty()) {
             Thread.sleep(1000);
-            TaskModDownload download = null;
-            for (TaskModDownload task :
+            ModDownloadTask download = null;
+            for (ModDownloadTask task :
                     downloadTasksList) {
                 if (!task.isAlive()) {
                     download = task;
@@ -305,10 +325,10 @@ public class TaskModsUpdater extends BThread {
                     matchingResult.type = SearchResult.Type.UPDATE_INSTALLED;
                     YamlSection jenkinsBuildId = modsConfig.get(
                             modsConfigName, download.getPlName(), "alternatives", "jenkins", "build-id");
-                    jenkinsBuildId.setValues(String.valueOf(download.searchResult.jenkinsId));
+                    jenkinsBuildId.setValues(String.valueOf(download.getSearchResult().jenkinsId));
                     YamlSection version = modsConfig.get(
                             modsConfigName, download.getPlName(), "version");
-                    version.setValues(download.searchResult.getLatestVersion());
+                    version.setValues(download.getSearchResult().getLatestVersion());
                 }
 
             }
@@ -337,6 +357,42 @@ public class TaskModsUpdater extends BThread {
 
     }
 
+    private SearchResult findSteamWorkshopUpdate(@NotNull SteamWorkshopMod mod) {
+        SearchResult result = new SearchResult(null, SearchResult.Type.UP_TO_DATE, mod.getVersion(), null, "steam-workshop", null, null, false);
+        result.mod = mod;
+
+        try {
+            SteamCMD.SteamWorkshopItemDetails details = createSteamCMD().getWorkshopItemDetails(mod.getPublishedId());
+            result.latestVersion = details.getTimeUpdated();
+            if (hasSteamWorkshopUpdate(mod, details.getTimeUpdated()))
+                result.type = SearchResult.Type.UPDATE_AVAILABLE;
+        } catch (Exception e) {
+            result.type = SearchResult.Type.API_ERROR;
+            result.setException(e);
+        }
+        return result;
+    }
+
+    private boolean hasSteamWorkshopUpdate(SteamWorkshopMod mod, String latestVersion) {
+        if (latestVersion == null || latestVersion.isEmpty())
+            return false;
+
+        String currentVersion = mod.getVersion();
+        if (currentVersion == null || currentVersion.isEmpty())
+            return true;
+        if (latestVersion.equals(currentVersion))
+            return false;
+        try {
+            return Long.parseLong(latestVersion) > Long.parseLong(currentVersion);
+        } catch (NumberFormatException e) {
+            return true;
+        }
+    }
+
+    SteamCMD createSteamCMD() {
+        return new SteamCMD();
+    }
+
     private void doDownloadLogic(@NotNull MinecraftMod mod, SearchResult result) {
         SearchResult.Type code = result.type;
         String type = result.getDownloadType(); // The file type to download (Note: When 'external' is returned nothing will be downloaded. Working on a fix for this!)
@@ -361,8 +417,24 @@ public class TaskModsUpdater extends BThread {
             }
 
             if (userProfile.equals(notifyProfile)) {
-                addInfo("NOTIFY: Mod '" + mod.getName() + "' has an update available (" + mod.getVersion() + " -> " + latest + "). Download url: " + downloadUrl);
+                if (mod instanceof SteamWorkshopMod)
+                    addInfo("NOTIFY: Steam Workshop mod '" + mod.getName() + "' has an update available (" + mod.getVersion() + " -> " + latest + ").");
+                else
+                    addInfo("NOTIFY: Mod '" + mod.getName() + "' has an update available (" + mod.getVersion() + " -> " + latest + "). Download url: " + downloadUrl);
             } else {
+                if (mod instanceof SteamWorkshopMod) {
+                    String workshopAppId = updaterConfig.mods_updater_steam_workshop_app_id.asString();
+                    if (workshopAppId == null || !workshopAppId.matches("\\d+")) {
+                        getWarnings().add(new BWarning(this, new Exception("Steam Workshop mod '" + mod.getName() + "' was found, but mods-updater.steam-workshop-app-id is not a numeric Steam app-id.")));
+                        return;
+                    }
+                    TaskSteamWorkshopModDownload task = new TaskSteamWorkshopModDownload("SteamWorkshopModDownloader", getManager(),
+                            (SteamWorkshopMod) mod, workshopAppId, userProfile, createSteamCMD(), result);
+                    downloadTasksList.add(task);
+                    task.start();
+                    return;
+                }
+
                 // Make sure that plName and plLatestVersion do not contain any slashes (/ or \) that could break the file name
                 UtilsFile utilsFile = new UtilsFile();
                 mod.setName(utilsFile.getValidFileName(mod.getName()));

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/TaskSteamWorkshopModDownload.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/TaskSteamWorkshopModDownload.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2024 Osiris-Team.
+ * All rights reserved.
+ *
+ * This software is copyrighted work, licensed under the terms
+ * of the MIT-License. Consult the "LICENSE" file for details.
+ */
+
+package com.osiris.autoplug.client.tasks.updater.mods;
+
+import com.osiris.autoplug.client.tasks.updater.search.SearchResult;
+import com.osiris.autoplug.client.utils.GD;
+import com.osiris.autoplug.client.utils.SteamCMD;
+import com.osiris.betterthread.BThread;
+import com.osiris.betterthread.BThreadManager;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+
+public class TaskSteamWorkshopModDownload extends BThread implements ModDownloadTask {
+    private final SteamWorkshopMod mod;
+    private final String workshopAppId;
+    private final String profile;
+    private final SteamCMD steamCMD;
+    private final SearchResult searchResult;
+    private boolean isDownloadSuccessful;
+    private boolean isInstallSuccessful;
+
+    public TaskSteamWorkshopModDownload(String name, BThreadManager manager, SteamWorkshopMod mod,
+                                        String workshopAppId, String profile, SteamCMD steamCMD,
+                                        SearchResult searchResult) {
+        super(name, manager);
+        this.mod = mod;
+        this.workshopAppId = workshopAppId;
+        this.profile = profile;
+        this.steamCMD = steamCMD;
+        this.searchResult = searchResult;
+    }
+
+    @Override
+    public void runAtStart() throws Exception {
+        super.runAtStart();
+
+        if (profile.equals("NOTIFY")) {
+            setStatus("Your profile doesn't allow downloads! Profile: " + profile);
+            finish(false);
+            return;
+        }
+
+        boolean success = steamCMD.installOrUpdateWorkshopItem(workshopAppId, mod.getPublishedId(), this::setStatus, this::addWarning);
+        if (!success) {
+            setStatus("Failed to download Steam Workshop mod " + mod.getName() + ".");
+            finish(false);
+            return;
+        }
+        isDownloadSuccessful = true;
+
+        File downloadedDir = steamCMD.getWorkshopItemDir(workshopAppId, mod.getPublishedId());
+        if (!downloadedDir.exists())
+            throw new Exception("SteamCMD reported success, but the Workshop item directory does not exist: " + downloadedDir);
+
+        File finalDest;
+        if (profile.equals("MANUAL")) {
+            finalDest = new File(GD.DOWNLOADS_DIR + "/steam-workshop/" + workshopAppId + "/" + mod.getPublishedId());
+        } else {
+            finalDest = mod.getDirectory();
+        }
+
+        if (finalDest.exists()) FileUtils.deleteDirectory(finalDest);
+        FileUtils.copyDirectory(downloadedDir, finalDest);
+        if (profile.equals("MANUAL")) {
+            setStatus("Downloaded Steam Workshop update for " + mod.getName() + " successfully!");
+            return;
+        }
+
+        isInstallSuccessful = true;
+        setStatus("Installed Steam Workshop update for " + mod.getName() + " successfully!");
+    }
+
+    public String getPlName() {
+        return mod.getName();
+    }
+
+    public SearchResult getSearchResult() {
+        return searchResult;
+    }
+
+    public boolean isDownloadSuccessful() {
+        return isDownloadSuccessful;
+    }
+
+    public boolean isInstallSuccessful() {
+        return isInstallSuccessful;
+    }
+}

--- a/src/main/java/com/osiris/autoplug/client/utils/SteamCMD.java
+++ b/src/main/java/com/osiris/autoplug/client/utils/SteamCMD.java
@@ -8,6 +8,9 @@
 
 package com.osiris.autoplug.client.utils;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.osiris.autoplug.client.configs.UpdaterConfig;
 import com.osiris.autoplug.client.tasks.updater.TaskDownload;
 import com.osiris.autoplug.client.utils.io.AsyncReader;
@@ -15,6 +18,11 @@ import com.osiris.autoplug.client.utils.terminal.AsyncTerminal;
 import com.osiris.betterthread.BThreadManager;
 import com.osiris.dyml.exceptions.*;
 import com.osiris.jlib.logger.AL;
+import okhttp3.FormBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 import org.rauschig.jarchivelib.ArchiveFormat;
 import org.rauschig.jarchivelib.Archiver;
 import org.rauschig.jarchivelib.ArchiverFactory;
@@ -35,6 +43,8 @@ import static com.osiris.jprocesses2.util.OS.isWindows;
 @SuppressWarnings({"WeakerAccess", "unused"})
 public class SteamCMD {
 
+    private static final String STEAM_WORKSHOP_DETAILS_URL = "https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/v1/";
+    private static final String steamcmdWorkshopCommand = "+login {LOGIN} +workshop_download_item {WORKSHOP_APP} {WORKSHOP_ITEM} validate +quit";
     private final String steamcmdArchive = "steamcmd" + (isWindows ? ".zip" : isMac ? "_osx.tar.gz" : "_linux.tar.gz");
     private final String steamcmdExtension = isWindows ? ".exe" : ".sh";
     private final String steamcmdExecutable = "steamcmd" + steamcmdExtension;
@@ -115,8 +125,7 @@ public class SteamCMD {
             AL.debug(this.getClass(), "Installing app " + appId + "...");
             onLog.accept("Installing app " + appId + "...");
 
-            String login = new UpdaterConfig().server_steamcmd_login.asString();
-            if (login == null || login.isEmpty()) login = "anonymous";
+            String login = getLogin();
 
             File gameInstallDir = new File(dirSteamServersDownloads + "/" + appId);
             gameInstallDir.mkdirs();
@@ -159,10 +168,140 @@ public class SteamCMD {
         }
     }
 
+    public boolean installOrUpdateWorkshopItem(String workshopAppId, String workshopItemId, Consumer<String> onLog, Consumer<String> onLogErr) {
+        try {
+            if (!installIfNeeded()) return false;
+            AL.debug(this.getClass(), "Installing workshop item " + workshopItemId + " for app " + workshopAppId + "...");
+            onLog.accept("Installing workshop item " + workshopItemId + "...");
+
+            String command = buildWorkshopItemCommand(getLogin(), workshopAppId, workshopItemId);
+            AtomicBoolean isFinished = new AtomicBoolean(false);
+            AtomicBoolean isSuccess = new AtomicBoolean(true);
+            AsyncTerminal terminal = new AsyncTerminal(destDir, line -> {
+                onLog.accept(line);
+                String lowerLine = line.toLowerCase();
+                if (lowerLine.startsWith("success.") && lowerLine.contains("item " + workshopItemId.toLowerCase()))
+                    isFinished.set(true);
+                if (lowerLine.startsWith("error!")) {
+                    isSuccess.set(false);
+                    isFinished.set(true);
+                }
+            }, line -> {
+                onLogErr.accept(line);
+                if (line.toLowerCase().contains("error")) {
+                    isSuccess.set(false);
+                    isFinished.set(true);
+                }
+            }, destExe.getAbsolutePath() + " " + command);
+
+            Thread thread = new Thread(() -> terminal.process.destroy());
+            Runtime.getRuntime().addShutdownHook(thread);
+            while (!isFinished.get() && terminal.process.isAlive()) Thread.sleep(100);
+            if (terminal.process.isAlive()) terminal.process.destroy();
+            Runtime.getRuntime().removeShutdownHook(thread);
+            return isSuccess.get() && getWorkshopItemDir(workshopAppId, workshopItemId).exists();
+        } catch (Exception e) {
+            AL.warn(e);
+            return false;
+        }
+    }
+
+    public SteamWorkshopItemDetails getWorkshopItemDetails(String workshopItemId) throws IOException {
+        Request request = new Request.Builder()
+                .url(STEAM_WORKSHOP_DETAILS_URL)
+                .post(new FormBody.Builder()
+                        .add("itemcount", "1")
+                        .add("publishedfileids[0]", workshopItemId)
+                        .build())
+                .header("User-Agent", "AutoPlug-Client - https://autoplug.one")
+                .build();
+
+        Response response = new OkHttpClient().newCall(request).execute();
+        ResponseBody body = null;
+        try {
+            if (response.code() != 200)
+                throw new IOException("Steam Workshop details request failed for item " + workshopItemId + " with code " + response.code() + " message: " + response.message());
+
+            body = response.body();
+            if (body == null)
+                throw new IOException("Steam Workshop details request returned no body for item " + workshopItemId);
+
+            JsonObject root = JsonParser.parseString(body.string()).getAsJsonObject();
+            JsonObject responseObject = root.getAsJsonObject("response");
+            JsonArray details = responseObject == null ? null : responseObject.getAsJsonArray("publishedfiledetails");
+            if (details == null || details.size() == 0)
+                throw new IOException("Steam Workshop details request returned no details for item " + workshopItemId);
+
+            JsonObject detail = details.get(0).getAsJsonObject();
+            int result = detail.has("result") ? detail.get("result").getAsInt() : 0;
+            if (result != 1)
+                throw new IOException("Steam Workshop details request failed for item " + workshopItemId + " with result " + result);
+
+            String timeUpdated = getString(detail, "time_updated");
+            if (timeUpdated == null || timeUpdated.isEmpty())
+                throw new IOException("Steam Workshop details for item " + workshopItemId + " did not contain time_updated.");
+
+            return new SteamWorkshopItemDetails(
+                    getString(detail, "publishedfileid"),
+                    getString(detail, "title"),
+                    timeUpdated);
+        } finally {
+            if (body != null) body.close();
+            response.close();
+        }
+    }
+
+    public File getWorkshopItemDir(String workshopAppId, String workshopItemId) {
+        return new File(destDir + "/steamapps/workshop/content/" + workshopAppId + "/" + workshopItemId);
+    }
+
+    static String buildWorkshopItemCommand(String login, String workshopAppId, String workshopItemId) {
+        return steamcmdWorkshopCommand
+                .replace("{LOGIN}", login)
+                .replace("{WORKSHOP_APP}", workshopAppId)
+                .replace("{WORKSHOP_ITEM}", workshopItemId);
+    }
+
+    private String getLogin() throws NotLoadedException, YamlReaderException, YamlWriterException, IOException, IllegalKeyException, DuplicateKeyException, IllegalListException {
+        String login = new UpdaterConfig().server_steamcmd_login.asString();
+        if (login == null || login.isEmpty()) login = "anonymous";
+        return login;
+    }
+
+    private static String getString(JsonObject object, String key) {
+        if (object == null || !object.has(key) || object.get(key).isJsonNull())
+            return null;
+        return object.get(key).getAsString();
+    }
+
     public String getResolutionForError(String error) {
         for (Map.Entry<String, String> entry : errorResolutions.entrySet())
             if (error.contains(entry.getKey())) return entry.getValue();
         return "Unknown. :(";
+    }
+
+    public static class SteamWorkshopItemDetails {
+        private final String publishedFileId;
+        private final String title;
+        private final String timeUpdated;
+
+        public SteamWorkshopItemDetails(String publishedFileId, String title, String timeUpdated) {
+            this.publishedFileId = publishedFileId;
+            this.title = title;
+            this.timeUpdated = timeUpdated;
+        }
+
+        public String getPublishedFileId() {
+            return publishedFileId;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public String getTimeUpdated() {
+            return timeUpdated;
+        }
     }
 
 }

--- a/src/test/java/com/osiris/autoplug/client/tasks/updater/mods/SteamWorkshopModTest.java
+++ b/src/test/java/com/osiris/autoplug/client/tasks/updater/mods/SteamWorkshopModTest.java
@@ -217,6 +217,26 @@ class SteamWorkshopModTest {
         }
     }
 
+    @Test
+    void invalidModsUpdaterProfileFallsBackToDefault() throws Exception {
+        File oldWorkingDir = GD.WORKING_DIR;
+        File oldDownloadsDir = GD.DOWNLOADS_DIR;
+        String oldUserDir = System.getProperty("user.dir");
+        useWorkingDir(tempDir);
+        try {
+            UpdaterConfig updaterConfig = new UpdaterConfig();
+            updaterConfig.mods_updater_profile.setValues("BROKEN");
+
+            updaterConfig.validateValues();
+
+            assertEquals("AUTOMATIC", updaterConfig.mods_updater_profile.asString());
+        } finally {
+            System.setProperty("user.dir", oldUserDir);
+            GD.WORKING_DIR = oldWorkingDir;
+            GD.DOWNLOADS_DIR = oldDownloadsDir;
+        }
+    }
+
     private File writeMeta(File modDir, String... lines) throws Exception {
         File metaFile = new File(modDir, "meta.cpp");
         Files.write(metaFile.toPath(), Arrays.asList(lines), StandardCharsets.UTF_8);

--- a/src/test/java/com/osiris/autoplug/client/tasks/updater/mods/SteamWorkshopModTest.java
+++ b/src/test/java/com/osiris/autoplug/client/tasks/updater/mods/SteamWorkshopModTest.java
@@ -97,6 +97,52 @@ class SteamWorkshopModTest {
     }
 
     @Test
+    void firstRunDetectionInstallsWhenMetaTimestampUsesDifferentDomainThanSteamApi() throws Exception {
+        File oldWorkingDir = GD.WORKING_DIR;
+        File oldDownloadsDir = GD.DOWNLOADS_DIR;
+        String oldUserDir = System.getProperty("user.dir");
+        useWorkingDir(tempDir);
+        try {
+            File modDir = tempDir.resolve("mods/@CF").toFile();
+            modDir.mkdirs();
+            writeMeta(modDir,
+                    "protocol = 1;",
+                    "publishedid = 1559212036;",
+                    "name = \"CF\";",
+                    "timestamp = 5249804932187309401;");
+
+            File downloadedDir = tempDir.resolve("steamcmd/steamapps/workshop/content/221100/1559212036").toFile();
+            downloadedDir.mkdirs();
+            Files.write(downloadedDir.toPath().resolve("updated.txt"), Arrays.asList("updated"), StandardCharsets.UTF_8);
+
+            configureUpdaterWithoutCachedMod();
+            FakeSteamCMD steamCMD = new FakeSteamCMD("1718030554", downloadedDir);
+
+            TaskModsUpdater task = new TaskModsUpdater("ModsUpdater", new BThreadManager()) {
+                @Override
+                SteamCMD createSteamCMD() {
+                    return steamCMD;
+                }
+            };
+            task.runAtStart();
+
+            assertEquals(1, steamCMD.detailsCalls);
+            assertEquals(1, steamCMD.updateCalls);
+            assertEquals("updated", Files.readAllLines(modDir.toPath().resolve("updated.txt"), StandardCharsets.UTF_8).get(0));
+            assertTrue(task.getWarnings().isEmpty());
+
+            ModsConfig modsConfig = new ModsConfig();
+            modsConfig.load();
+            assertEquals("1559212036", modsConfig.get("mods", "CF", "steam-workshop-id").asString());
+            assertEquals("1718030554", modsConfig.get("mods", "CF", "version").asString());
+        } finally {
+            System.setProperty("user.dir", oldUserDir);
+            GD.WORKING_DIR = oldWorkingDir;
+            GD.DOWNLOADS_DIR = oldDownloadsDir;
+        }
+    }
+
+    @Test
     void updaterSkipsDownloadWhenCachedSteamVersionMatches() throws Exception {
         File oldWorkingDir = GD.WORKING_DIR;
         File oldDownloadsDir = GD.DOWNLOADS_DIR;
@@ -193,6 +239,19 @@ class SteamWorkshopModTest {
     }
 
     private void configureUpdater(String cachedWorkshopVersion, String profile) throws Exception {
+        configureUpdaterProfile(profile);
+
+        ModsConfig modsConfig = new ModsConfig();
+        modsConfig.put("mods", "CF", "version").setValues(cachedWorkshopVersion);
+        modsConfig.put("mods", "CF", "steam-workshop-id").setValues("1559212036");
+        modsConfig.save();
+    }
+
+    private void configureUpdaterWithoutCachedMod() throws Exception {
+        configureUpdaterProfile("AUTOMATIC");
+    }
+
+    private void configureUpdaterProfile(String profile) throws Exception {
         UpdaterConfig updaterConfig = new UpdaterConfig();
         updaterConfig.mods_updater.setValues("true");
         updaterConfig.mods_updater_profile.setValues(profile);
@@ -201,11 +260,6 @@ class SteamWorkshopModTest {
         updaterConfig.mods_updater_async.setValues("false");
         updaterConfig.mods_updater_steam_workshop_app_id.setValues("221100");
         updaterConfig.save();
-
-        ModsConfig modsConfig = new ModsConfig();
-        modsConfig.put("mods", "CF", "version").setValues(cachedWorkshopVersion);
-        modsConfig.put("mods", "CF", "steam-workshop-id").setValues("1559212036");
-        modsConfig.save();
     }
 
     private static class FakeSteamCMD extends SteamCMD {

--- a/src/test/java/com/osiris/autoplug/client/tasks/updater/mods/SteamWorkshopModTest.java
+++ b/src/test/java/com/osiris/autoplug/client/tasks/updater/mods/SteamWorkshopModTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2024 Osiris-Team.
+ * All rights reserved.
+ *
+ * This software is copyrighted work, licensed under the terms
+ * of the MIT-License. Consult the "LICENSE" file for details.
+ */
+
+package com.osiris.autoplug.client.tasks.updater.mods;
+
+import com.osiris.autoplug.client.configs.ModsConfig;
+import com.osiris.autoplug.client.configs.UpdaterConfig;
+import com.osiris.autoplug.client.utils.GD;
+import com.osiris.autoplug.client.utils.SteamCMD;
+import com.osiris.betterthread.BThreadManager;
+import com.osiris.jlib.logger.AL;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SteamWorkshopModTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void readsPublishedIdAndNameFromMetaCpp() throws Exception {
+        File modDir = tempDir.resolve("@CF").toFile();
+        modDir.mkdirs();
+        File metaFile = writeMeta(modDir,
+                "protocol = 1;",
+                "publishedid = 1559212036;",
+                "name = \"CF\";",
+                "timestamp = 5249804932187309401;");
+
+        SteamWorkshopMod mod = SteamWorkshopMod.readFromMeta(modDir, metaFile);
+
+        assertEquals(modDir, mod.getDirectory());
+        assertEquals("CF", mod.getName());
+        assertEquals("1559212036", mod.getPublishedId());
+        assertEquals("5249804932187309401", mod.getTimestamp());
+    }
+
+    @Test
+    void updaterInstallsNewerWorkshopContentAndCachesSteamVersion() throws Exception {
+        File oldWorkingDir = GD.WORKING_DIR;
+        File oldDownloadsDir = GD.DOWNLOADS_DIR;
+        String oldUserDir = System.getProperty("user.dir");
+        useWorkingDir(tempDir);
+        try {
+            File modDir = tempDir.resolve("mods/@CF").toFile();
+            modDir.mkdirs();
+            writeMeta(modDir, "publishedid = 1559212036;", "name = \"CF\";", "timestamp = 100;");
+            Files.write(modDir.toPath().resolve("old.txt"), Arrays.asList("old"), StandardCharsets.UTF_8);
+
+            File downloadedDir = tempDir.resolve("steamcmd/steamapps/workshop/content/221100/1559212036").toFile();
+            downloadedDir.mkdirs();
+            writeMeta(downloadedDir, "publishedid = 1559212036;", "name = \"CF\";", "timestamp = 200;");
+            Files.write(downloadedDir.toPath().resolve("updated.txt"), Arrays.asList("updated"), StandardCharsets.UTF_8);
+
+            configureUpdater("100");
+            FakeSteamCMD steamCMD = new FakeSteamCMD("200", downloadedDir);
+
+            TaskModsUpdater task = new TaskModsUpdater("ModsUpdater", new BThreadManager()) {
+                @Override
+                SteamCMD createSteamCMD() {
+                    return steamCMD;
+                }
+            };
+            task.runAtStart();
+
+            assertEquals(1, steamCMD.detailsCalls);
+            assertEquals(1, steamCMD.updateCalls);
+            assertEquals("221100", steamCMD.workshopAppId);
+            assertEquals("1559212036", steamCMD.workshopItemId);
+            assertEquals("updated", Files.readAllLines(modDir.toPath().resolve("updated.txt"), StandardCharsets.UTF_8).get(0));
+            assertTrue(task.getWarnings().isEmpty());
+
+            ModsConfig modsConfig = new ModsConfig();
+            modsConfig.load();
+            assertEquals("1559212036", modsConfig.get("mods", "CF", "steam-workshop-id").asString());
+            assertEquals("200", modsConfig.get("mods", "CF", "version").asString());
+        } finally {
+            System.setProperty("user.dir", oldUserDir);
+            GD.WORKING_DIR = oldWorkingDir;
+            GD.DOWNLOADS_DIR = oldDownloadsDir;
+        }
+    }
+
+    @Test
+    void updaterSkipsDownloadWhenCachedSteamVersionMatches() throws Exception {
+        File oldWorkingDir = GD.WORKING_DIR;
+        File oldDownloadsDir = GD.DOWNLOADS_DIR;
+        String oldUserDir = System.getProperty("user.dir");
+        useWorkingDir(tempDir);
+        try {
+            File modDir = tempDir.resolve("mods/@CF").toFile();
+            modDir.mkdirs();
+            writeMeta(modDir, "publishedid = 1559212036;", "name = \"CF\";", "timestamp = 100;");
+
+            configureUpdater("200");
+            FakeSteamCMD steamCMD = new FakeSteamCMD("200", null);
+
+            TaskModsUpdater task = new TaskModsUpdater("ModsUpdater", new BThreadManager()) {
+                @Override
+                SteamCMD createSteamCMD() {
+                    return steamCMD;
+                }
+            };
+            task.runAtStart();
+
+            assertEquals(1, steamCMD.detailsCalls);
+            assertEquals(0, steamCMD.updateCalls);
+            assertFalse(Files.exists(modDir.toPath().resolve("updated.txt")));
+            assertTrue(task.getWarnings().isEmpty());
+        } finally {
+            System.setProperty("user.dir", oldUserDir);
+            GD.WORKING_DIR = oldWorkingDir;
+            GD.DOWNLOADS_DIR = oldDownloadsDir;
+        }
+    }
+
+    @Test
+    void manualProfileDownloadsWorkshopContentWithoutInstallingOrCachingVersion() throws Exception {
+        File oldWorkingDir = GD.WORKING_DIR;
+        File oldDownloadsDir = GD.DOWNLOADS_DIR;
+        String oldUserDir = System.getProperty("user.dir");
+        useWorkingDir(tempDir);
+        try {
+            File modDir = tempDir.resolve("mods/@CF").toFile();
+            modDir.mkdirs();
+            writeMeta(modDir, "publishedid = 1559212036;", "name = \"CF\";", "timestamp = 100;");
+            Files.write(modDir.toPath().resolve("old.txt"), Arrays.asList("old"), StandardCharsets.UTF_8);
+
+            File downloadedDir = tempDir.resolve("steamcmd/steamapps/workshop/content/221100/1559212036").toFile();
+            downloadedDir.mkdirs();
+            Files.write(downloadedDir.toPath().resolve("updated.txt"), Arrays.asList("updated"), StandardCharsets.UTF_8);
+
+            configureUpdater("100", "MANUAL");
+            FakeSteamCMD steamCMD = new FakeSteamCMD("200", downloadedDir);
+
+            TaskModsUpdater task = new TaskModsUpdater("ModsUpdater", new BThreadManager()) {
+                @Override
+                SteamCMD createSteamCMD() {
+                    return steamCMD;
+                }
+            };
+            task.runAtStart();
+
+            assertEquals(1, steamCMD.updateCalls);
+            assertFalse(Files.exists(modDir.toPath().resolve("updated.txt")));
+            assertEquals("updated", Files.readAllLines(GD.DOWNLOADS_DIR.toPath()
+                    .resolve("steam-workshop/221100/1559212036/updated.txt"), StandardCharsets.UTF_8).get(0));
+
+            ModsConfig modsConfig = new ModsConfig();
+            modsConfig.load();
+            assertEquals("100", modsConfig.get("mods", "CF", "version").asString());
+        } finally {
+            System.setProperty("user.dir", oldUserDir);
+            GD.WORKING_DIR = oldWorkingDir;
+            GD.DOWNLOADS_DIR = oldDownloadsDir;
+        }
+    }
+
+    private File writeMeta(File modDir, String... lines) throws Exception {
+        File metaFile = new File(modDir, "meta.cpp");
+        Files.write(metaFile.toPath(), Arrays.asList(lines), StandardCharsets.UTF_8);
+        return metaFile;
+    }
+
+    private void useWorkingDir(Path dir) {
+        System.setProperty("user.dir", dir.toAbsolutePath().toString());
+        GD.VERSION = "AutoPlug-Client Test-Version";
+        GD.WORKING_DIR = dir.toFile();
+        GD.DOWNLOADS_DIR = dir.resolve("autoplug/downloads").toFile();
+        GD.DOWNLOADS_DIR.mkdirs();
+        File logFile = dir.resolve("autoplug/logs/latest.log").toFile();
+        logFile.getParentFile().mkdirs();
+        new AL().start("AL", true, logFile, false, false);
+    }
+
+    private void configureUpdater(String cachedWorkshopVersion) throws Exception {
+        configureUpdater(cachedWorkshopVersion, "AUTOMATIC");
+    }
+
+    private void configureUpdater(String cachedWorkshopVersion, String profile) throws Exception {
+        UpdaterConfig updaterConfig = new UpdaterConfig();
+        updaterConfig.mods_updater.setValues("true");
+        updaterConfig.mods_updater_profile.setValues(profile);
+        updaterConfig.mods_updater_path.setValues("./mods");
+        updaterConfig.mods_updater_version.setValues("1.20.1");
+        updaterConfig.mods_updater_async.setValues("false");
+        updaterConfig.mods_updater_steam_workshop_app_id.setValues("221100");
+        updaterConfig.save();
+
+        ModsConfig modsConfig = new ModsConfig();
+        modsConfig.put("mods", "CF", "version").setValues(cachedWorkshopVersion);
+        modsConfig.put("mods", "CF", "steam-workshop-id").setValues("1559212036");
+        modsConfig.save();
+    }
+
+    private static class FakeSteamCMD extends SteamCMD {
+        final String latestVersion;
+        final File workshopItemDir;
+        int detailsCalls;
+        int updateCalls;
+        String workshopAppId;
+        String workshopItemId;
+
+        FakeSteamCMD(String latestVersion, File workshopItemDir) {
+            this.latestVersion = latestVersion;
+            this.workshopItemDir = workshopItemDir;
+        }
+
+        @Override
+        public SteamWorkshopItemDetails getWorkshopItemDetails(String workshopItemId) {
+            detailsCalls++;
+            return new SteamWorkshopItemDetails(workshopItemId, "CF", latestVersion);
+        }
+
+        @Override
+        public boolean installOrUpdateWorkshopItem(String workshopAppId, String workshopItemId, Consumer<String> onLog, Consumer<String> onLogErr) {
+            updateCalls++;
+            this.workshopAppId = workshopAppId;
+            this.workshopItemId = workshopItemId;
+            onLog.accept("Success. Downloaded item " + workshopItemId);
+            return true;
+        }
+
+        @Override
+        public File getWorkshopItemDir(String workshopAppId, String workshopItemId) {
+            return workshopItemDir;
+        }
+    }
+}

--- a/src/test/java/com/osiris/autoplug/client/utils/SteamCMDTest.java
+++ b/src/test/java/com/osiris/autoplug/client/utils/SteamCMDTest.java
@@ -13,7 +13,16 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 class SteamCMDTest {
+
+    @Test
+    void buildsWorkshopItemCommand() {
+        String command = SteamCMD.buildWorkshopItemCommand("anonymous", "221100", "1559212036");
+
+        assertEquals("+login anonymous +workshop_download_item 221100 1559212036 validate +quit", command);
+    }
 
     @Test
     void installSteamcmd() throws IOException {


### PR DESCRIPTION
Closes #215

Summary:
- Detect Steam Workshop mod directories by reading `meta.cpp` files under the configured `mods-updater.path`.
- Store each detected `publishedid` in `mods.yml` as `steam-workshop-id`.
- Check Steam Workshop metadata through Steam's published-file details API and compare against the cached Steam `time_updated` value.
- Treat first-time detected Workshop mods as uncached, so DayZ `meta.cpp` timestamps are not compared against Steam API Unix timestamps.
- Download Workshop updates through SteamCMD with `workshop_download_item`.
- Add `mods-updater.steam-workshop-app-id`, defaulting to DayZ's Workshop app id `221100`, so DayZ server installs do not have to reuse the dedicated-server app id for Workshop downloads.
- Preserve updater profile behavior: `NOTIFY` reports updates, `MANUAL` downloads Workshop content into `autoplug/downloads/steam-workshop`, and `AUTOMATIC` installs the downloaded Workshop content back into the existing mod folder.

Validation:
- `mvn -q -Dtest=SteamWorkshopModTest,SteamCMDTest#buildsWorkshopItemCommand test`
- `mvn -q -DskipTests package`
- `git diff --check f9b04ef..HEAD`
- 

Note: AI was mostly used for this PR. I, the human, validated it.