### PR TITLE
Add Steam Workshop mod updater support

### DIFF
--- a/src/main/java/com/osiris/autoplug/client/configs/ModsConfig.java
+++ b/src/main/java/com/osiris/autoplug/client/configs/ModsConfig.java
@@ -44,6 +44,7 @@ public class ModsConfig extends MyYaml {
                         "If there are mods that weren't found by the search-algorithm, you can add an id (spigot or bukkit) and a custom link (optional & must be a static link to the latest mod jar).\n" +
                         "modrinth-id: Is the 'Project-ID' and can be found on the mods modrinth site inside of the 'About' box, under 'Technical Information' at the bottom left.\n" +
                         "curseforge-id: Is also called 'Project-ID' and can be found on the mods curseforge site inside of the 'About' box at the right.\n" +
+                        "steam-workshop-id: Is read from Steam Workshop mod folders that contain a meta.cpp with a publishedid value.\n" +
                         "ignore-content-type: If true, does not check if the downloaded file is of type jar or zip, and downloads it anyway.\n" +
                         "force-latest: If true, does not search for updates compatible with this Minecraft version and simply picks the latest release.\n" +
                         "force-update: If true, downloads the update every time even if its already on the latest version.\n" +

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/ModDownloadTask.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/ModDownloadTask.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 Osiris-Team.
+ * All rights reserved.
+ *
+ * This software is copyrighted work, licensed under the terms
+ * of the MIT-License. Consult the "LICENSE" file for details.
+ */
+
+package com.osiris.autoplug.client.tasks.updater.mods;
+
+import com.osiris.autoplug.client.tasks.updater.search.SearchResult;
+
+interface ModDownloadTask {
+    void start();
+
+    boolean isAlive();
+
+    String getPlName();
+
+    SearchResult getSearchResult();
+
+    boolean isDownloadSuccessful();
+
+    boolean isInstallSuccessful();
+}

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/SteamWorkshopMod.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/SteamWorkshopMod.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2024 Osiris-Team.
+ * All rights reserved.
+ *
+ * This software is copyrighted work, licensed under the terms
+ * of the MIT-License. Consult the "LICENSE" file for details.
+ */
+
+package com.osiris.autoplug.client.tasks.updater.mods;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+public class SteamWorkshopMod extends MinecraftMod {
+    private final File directory;
+    private String publishedId;
+
+    public SteamWorkshopMod(File directory, String name, String publishedId) {
+        this(directory, name, publishedId, null);
+    }
+
+    public SteamWorkshopMod(File directory, String name, String publishedId, String timestamp) {
+        super(directory.getAbsolutePath(), name, timestamp != null ? timestamp : publishedId, "Steam Workshop", null, null, null);
+        this.directory = directory;
+        this.publishedId = publishedId;
+    }
+
+    public File getDirectory() {
+        return directory;
+    }
+
+    public String getPublishedId() {
+        return publishedId;
+    }
+
+    public void setPublishedId(String publishedId) {
+        this.publishedId = publishedId;
+        if (getVersion() == null)
+            setVersion(publishedId);
+    }
+
+    @NotNull
+    public static List<SteamWorkshopMod> findIn(File dir) throws IOException {
+        if (!dir.exists()) throw new FileNotFoundException("Directory does not exist: " + dir);
+        List<SteamWorkshopMod> mods = new ArrayList<>();
+        File[] files = dir.listFiles();
+        if (files == null) return mods;
+        Arrays.sort(files, Comparator.comparing(File::getName));
+        for (File file : files) {
+            if (!file.isDirectory()) continue;
+            File metaFile = new File(file, "meta.cpp");
+            if (metaFile.exists())
+                mods.add(readFromMeta(file, metaFile));
+        }
+        return mods;
+    }
+
+    static SteamWorkshopMod readFromMeta(File modDir, File metaFile) throws IOException {
+        String name = modDir.getName();
+        String publishedId = null;
+        String timestamp = null;
+        for (String line : Files.readAllLines(metaFile.toPath(), StandardCharsets.UTF_8)) {
+            String trimmedLine = line.trim();
+            if (trimmedLine.isEmpty() || trimmedLine.startsWith("//")) continue;
+
+            int equalsIndex = trimmedLine.indexOf('=');
+            if (equalsIndex < 0) continue;
+
+            String key = trimmedLine.substring(0, equalsIndex).trim();
+            String value = trimmedLine.substring(equalsIndex + 1).trim();
+            int semicolonIndex = value.indexOf(';');
+            if (semicolonIndex >= 0)
+                value = value.substring(0, semicolonIndex);
+            value = value.trim();
+            if (value.startsWith("\"") && value.endsWith("\"") && value.length() >= 2)
+                value = value.substring(1, value.length() - 1);
+
+            if (key.equals("name")) name = value;
+            if (key.equals("publishedid")) publishedId = value;
+            if (key.equals("timestamp")) timestamp = value;
+        }
+
+        if (publishedId == null || !publishedId.matches("\\d+"))
+            throw new IOException("Failed to read publishedid from " + metaFile);
+
+        return new SteamWorkshopMod(modDir, name, publishedId, timestamp);
+    }
+}

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/TaskModDownload.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/TaskModDownload.java
@@ -25,7 +25,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 
 
-public class TaskModDownload extends BThread {
+public class TaskModDownload extends BThread implements ModDownloadTask {
     private final String plName;
     private final String plLatestVersion;
     private final String url;
@@ -181,6 +181,10 @@ public class TaskModDownload extends BThread {
 
     public String getPlName() {
         return plName;
+    }
+
+    public SearchResult getSearchResult() {
+        return searchResult;
     }
 
     public String getPlLatestVersion() {

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/TaskModsUpdater.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/TaskModsUpdater.java
@@ -15,6 +15,7 @@ import com.osiris.autoplug.client.managers.FileManager;
 import com.osiris.autoplug.client.tasks.updater.plugins.ResourceFinder;
 import com.osiris.autoplug.client.tasks.updater.search.SearchResult;
 import com.osiris.autoplug.client.utils.GD;
+import com.osiris.autoplug.client.utils.SteamCMD;
 import com.osiris.autoplug.client.utils.UtilsFile;
 import com.osiris.autoplug.client.utils.UtilsMinecraft;
 import com.osiris.betterthread.BThread;
@@ -40,7 +41,7 @@ public class TaskModsUpdater extends BThread {
     private final String manualProfile = "MANUAL";
     private final String automaticProfile = "AUTOMATIC";
     private final int updatesDownloaded = 0;
-    private final List<TaskModDownload> downloadTasksList = new ArrayList<>();
+    private final List<ModDownloadTask> downloadTasksList = new ArrayList<>();
     @NotNull
     private final List<MinecraftMod> includedMods = new ArrayList<>();
     @NotNull
@@ -81,7 +82,9 @@ public class TaskModsUpdater extends BThread {
         setStatus("Fetching latest mod data...");
 
         userProfile = updaterConfig.mods_updater_profile.asString();
-        this.allMods.addAll(new UtilsMinecraft().getMods(FileManager.convertRelativeToAbsolutePath(updaterConfig.mods_updater_path.asString())));
+        File modsDir = FileManager.convertRelativeToAbsolutePath(updaterConfig.mods_updater_path.asString());
+        this.allMods.addAll(new UtilsMinecraft().getMods(modsDir));
+        this.allMods.addAll(SteamWorkshopMod.findIn(modsDir));
 
         for (MinecraftMod installedMod :
                 allMods) {
@@ -96,6 +99,7 @@ public class TaskModsUpdater extends BThread {
                 YamlSection author = modsConfig.put(name, plName, "author").setDefValues(installedMod.getAuthor());
                 YamlSection modrinthId = modsConfig.put(name, plName, "modrinth-id");
                 YamlSection curseforgeId = modsConfig.put(name, plName, "curseforge-id");
+                YamlSection steamWorkshopId = modsConfig.put(name, plName, "steam-workshop-id");
                 YamlSection ignoreContentType = modsConfig.put(name, plName, "ignore-content-type").setDefValues("false");
                 YamlSection forceLatest = modsConfig.put(name, plName, "force-latest").setDefValues("false");
                 YamlSection forceUpdate = modsConfig.put(name, plName, "force-update").setDefValues("false");
@@ -111,6 +115,8 @@ public class TaskModsUpdater extends BThread {
                     modrinthId.setValues(installedMod.modrinthId);
                 if (installedMod.curseforgeId != null && curseforgeId.asString() == null)
                     curseforgeId.setValues(installedMod.curseforgeId);
+                if (installedMod instanceof SteamWorkshopMod)
+                    steamWorkshopId.setValues(((SteamWorkshopMod) installedMod).getPublishedId());
 
                 // Update the detailed mods in-memory values
                 installedMod.modrinthId = (modrinthId.asString());
@@ -125,6 +131,15 @@ public class TaskModsUpdater extends BThread {
                 installedMod.jenkinsArtifactName = (jenkinsArtifactName.asString());
                 installedMod.jenkinsBuildId = (jenkinsBuildId.asInt());
                 installedMod.forceUpdate = forceUpdate.asBoolean();
+                if (installedMod instanceof SteamWorkshopMod) {
+                    ((SteamWorkshopMod) installedMod).setPublishedId(steamWorkshopId.asString());
+                    installedMod.setVersion(version.asString());
+                    if (exclude.asBoolean())
+                        excludedMods.add(installedMod);
+                    else
+                        includedMods.add(installedMod);
+                    continue;
+                }
 
                 // Check for missing author in internal config
                 if ((installedMod.getVersion() == null)
@@ -184,10 +199,11 @@ public class TaskModsUpdater extends BThread {
         int sizeBukkitMods = 0;
         int sizeUnknownMods = 0;
         int sizeCustomMods = 0;
+        int sizeSteamWorkshopMods = 0;
 
 
         String mcVersion = updaterConfig.mods_updater_version.asString();
-        if (mcVersion == null) updaterConfig.server_updater_version.asString();
+        if (mcVersion == null) mcVersion = updaterConfig.server_updater_version.asString();
         if (mcVersion == null) mcVersion = Server.getMCVersion();
 
         ExecutorService executorService;
@@ -201,7 +217,10 @@ public class TaskModsUpdater extends BThread {
                 includedMods) {
             try {
                 setStatus("Initialising update check for  " + mod.getName() + "...");
-                if (mod.customCheckURL != null) { // Custom Check
+                if (mod instanceof SteamWorkshopMod) {
+                    sizeSteamWorkshopMods++;
+                    activeFutures.add(executorService.submit(() -> new ResourceFinder().findBySteamWorkshop((SteamWorkshopMod) mod, getWorkshopAppId(), createSteamCMD())));
+                } else if (mod.customCheckURL != null) { // Custom Check
                     sizeCustomMods++;
                     activeFutures.add(executorService.submit(() -> new ResourceFinder().findByCustomCheckURL(mod)));
                 } else if (mod.jenkinsProjectUrl != null) { // JENKINS MOD
@@ -272,12 +291,13 @@ public class TaskModsUpdater extends BThread {
                 }
             }
         }
+        executorService.shutdown();
 
         // Wait until all download tasks have finished.
         while (!downloadTasksList.isEmpty()) {
             Thread.sleep(1000);
-            TaskModDownload download = null;
-            for (TaskModDownload task :
+            ModDownloadTask download = null;
+            for (ModDownloadTask task :
                     downloadTasksList) {
                 if (!task.isAlive()) {
                     download = task;
@@ -305,10 +325,11 @@ public class TaskModsUpdater extends BThread {
                     matchingResult.type = SearchResult.Type.UPDATE_INSTALLED;
                     YamlSection jenkinsBuildId = modsConfig.get(
                             modsConfigName, download.getPlName(), "alternatives", "jenkins", "build-id");
-                    jenkinsBuildId.setValues(String.valueOf(download.searchResult.jenkinsId));
+                    if (matchingResult.mod.jenkinsProjectUrl != null)
+                        jenkinsBuildId.setValues(String.valueOf(download.getSearchResult().jenkinsId));
                     YamlSection version = modsConfig.get(
                             modsConfigName, download.getPlName(), "version");
-                    version.setValues(download.searchResult.getLatestVersion());
+                    version.setValues(download.getSearchResult().getLatestVersion());
                 }
 
             }
@@ -337,6 +358,17 @@ public class TaskModsUpdater extends BThread {
 
     }
 
+    private String getWorkshopAppId() {
+        String workshopAppId = updaterConfig.server_software.asString();
+        if (workshopAppId == null || !workshopAppId.matches("\\d+"))
+            return null;
+        return workshopAppId;
+    }
+
+    SteamCMD createSteamCMD() {
+        return new SteamCMD();
+    }
+
     private void doDownloadLogic(@NotNull MinecraftMod mod, SearchResult result) {
         SearchResult.Type code = result.type;
         String type = result.getDownloadType(); // The file type to download (Note: When 'external' is returned nothing will be downloaded. Working on a fix for this!)
@@ -361,8 +393,25 @@ public class TaskModsUpdater extends BThread {
             }
 
             if (userProfile.equals(notifyProfile)) {
-                addInfo("NOTIFY: Mod '" + mod.getName() + "' has an update available (" + mod.getVersion() + " -> " + latest + "). Download url: " + downloadUrl);
+                if (mod instanceof SteamWorkshopMod)
+                    addInfo("NOTIFY: Steam Workshop mod '" + mod.getName() + "' has an update available (" + mod.getVersion() + " -> " + latest + ").");
+                else
+                    addInfo("NOTIFY: Mod '" + mod.getName() + "' has an update available (" + mod.getVersion() + " -> " + latest + "). Download url: " + downloadUrl);
             } else {
+                if (mod instanceof SteamWorkshopMod) {
+                    String workshopAppId = getWorkshopAppId();
+                    if (workshopAppId == null) {
+                        getWarnings().add(new BWarning(this, new Exception("Steam Workshop mod '" + mod.getName() + "' was found, but server-updater.software is not a numeric Steam app-id.")));
+                        return;
+                    }
+
+                    TaskSteamWorkshopModDownload task = new TaskSteamWorkshopModDownload("SteamWorkshopModDownloader", getManager(),
+                            (SteamWorkshopMod) mod, workshopAppId, userProfile, createSteamCMD(), result);
+                    downloadTasksList.add(task);
+                    task.start();
+                    return;
+                }
+
                 // Make sure that plName and plLatestVersion do not contain any slashes (/ or \) that could break the file name
                 UtilsFile utilsFile = new UtilsFile();
                 mod.setName(utilsFile.getValidFileName(mod.getName()));

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/TaskSteamWorkshopModDownload.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/mods/TaskSteamWorkshopModDownload.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2024 Osiris-Team.
+ * All rights reserved.
+ *
+ * This software is copyrighted work, licensed under the terms
+ * of the MIT-License. Consult the "LICENSE" file for details.
+ */
+
+package com.osiris.autoplug.client.tasks.updater.mods;
+
+import com.osiris.autoplug.client.tasks.updater.search.SearchResult;
+import com.osiris.autoplug.client.utils.SteamCMD;
+import com.osiris.betterthread.BThread;
+import com.osiris.betterthread.BThreadManager;
+import com.osiris.jlib.logger.AL;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+
+public class TaskSteamWorkshopModDownload extends BThread implements ModDownloadTask {
+    private final SteamWorkshopMod mod;
+    private final String workshopAppId;
+    private final String profile;
+    private final SteamCMD steamCMD;
+    private final SearchResult searchResult;
+    private boolean isDownloadSuccessful;
+    private boolean isInstallSuccessful;
+
+    public TaskSteamWorkshopModDownload(String name, BThreadManager manager, SteamWorkshopMod mod,
+                                        String workshopAppId, String profile, SteamCMD steamCMD,
+                                        SearchResult searchResult) {
+        super(name, manager);
+        this.mod = mod;
+        this.workshopAppId = workshopAppId;
+        this.profile = profile;
+        this.steamCMD = steamCMD;
+        this.searchResult = searchResult;
+    }
+
+    @Override
+    public void runAtStart() throws Exception {
+        super.runAtStart();
+
+        if (profile.equals("NOTIFY")) {
+            setStatus("Your profile doesn't allow downloads! Profile: " + profile);
+            finish(false);
+            return;
+        }
+
+        setStatus("Downloading Steam Workshop mod " + mod.getName() + "...");
+        boolean isSuccess = steamCMD.installOrUpdateWorkshopItem(workshopAppId, mod.getPublishedId(),
+                line -> {
+                    AL.debug(this.getClass(), "SteamCMD-Out: " + line);
+                    setStatus(line);
+                }, errLine -> {
+                    AL.debug(this.getClass(), "SteamCMD-Err-Out: " + errLine);
+                    setStatus(errLine);
+                    addWarning(errLine);
+                });
+        if (!isSuccess)
+            throw new Exception("Failed to update Steam Workshop mod '" + mod.getName() + "' via SteamCMD.");
+
+        isDownloadSuccessful = true;
+        File downloadedDir = steamCMD.getWorkshopItemDir(workshopAppId, mod.getPublishedId());
+        if (profile.equals("MANUAL")) {
+            setStatus("Downloaded Steam Workshop mod " + mod.getName() + " to " + downloadedDir.getAbsolutePath());
+            return;
+        }
+
+        setStatus("Installing Steam Workshop mod " + mod.getName() + "...");
+        FileUtils.copyDirectory(downloadedDir, mod.getDirectory());
+        isInstallSuccessful = true;
+        setStatus("Installed update for " + mod.getName() + " successfully!");
+    }
+
+    public String getPlName() {
+        return mod.getName();
+    }
+
+    public SearchResult getSearchResult() {
+        return searchResult;
+    }
+
+    public boolean isDownloadSuccessful() {
+        return isDownloadSuccessful;
+    }
+
+    public boolean isInstallSuccessful() {
+        return isInstallSuccessful;
+    }
+}

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/plugins/ResourceFinder.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/plugins/ResourceFinder.java
@@ -13,14 +13,17 @@ import com.osiris.autoplug.client.tasks.updater.mods.CurseForgeAPI;
 import com.osiris.autoplug.client.tasks.updater.mods.InstalledModLoader;
 import com.osiris.autoplug.client.tasks.updater.mods.MinecraftMod;
 import com.osiris.autoplug.client.tasks.updater.mods.ModrinthAPI;
+import com.osiris.autoplug.client.tasks.updater.mods.SteamWorkshopMod;
 import com.osiris.autoplug.client.tasks.updater.search.CustomCheckURL;
 import com.osiris.autoplug.client.tasks.updater.search.GithubSearch;
 import com.osiris.autoplug.client.tasks.updater.search.JenkinsSearch;
 import com.osiris.autoplug.client.tasks.updater.search.SearchResult;
+import com.osiris.autoplug.client.tasks.updater.search.SteamWorkshopSearch;
 import com.osiris.autoplug.client.tasks.updater.search.bukkit.BukkitSearchById;
 import com.osiris.autoplug.client.tasks.updater.search.spigot.SpigotSearchByAuthor;
 import com.osiris.autoplug.client.tasks.updater.search.spigot.SpigotSearchById;
 import com.osiris.autoplug.client.tasks.updater.search.spigot.SpigotSearchByName;
+import com.osiris.autoplug.client.utils.SteamCMD;
 
 public class ResourceFinder {
 
@@ -62,6 +65,14 @@ public class ResourceFinder {
 
         sr.mod = mod;
         return sr;
+    }
+
+    public SearchResult findBySteamWorkshop(SteamWorkshopMod mod, String workshopAppId) {
+        return findBySteamWorkshop(mod, workshopAppId, new SteamCMD());
+    }
+
+    public SearchResult findBySteamWorkshop(SteamWorkshopMod mod, String workshopAppId, SteamCMD steamCMD) {
+        return new SteamWorkshopSearch().search(mod, workshopAppId, steamCMD);
     }
 
     public SearchResult findPluginBySpigotId(MinecraftPlugin plugin) {

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/search/SteamWorkshopSearch.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/search/SteamWorkshopSearch.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024 Osiris-Team.
+ * All rights reserved.
+ *
+ * This software is copyrighted work, licensed under the terms
+ * of the MIT-License. Consult the "LICENSE" file for details.
+ */
+
+package com.osiris.autoplug.client.tasks.updater.search;
+
+import com.osiris.autoplug.client.tasks.updater.mods.SteamWorkshopMod;
+import com.osiris.autoplug.client.utils.SteamCMD;
+import org.jetbrains.annotations.NotNull;
+
+public class SteamWorkshopSearch {
+
+    public SearchResult search(@NotNull SteamWorkshopMod mod, String workshopAppId, SteamCMD steamCMD) {
+        SearchResult result = new SearchResult(null, SearchResult.Type.UP_TO_DATE, mod.getVersion(), null, "steam-workshop", null, null, false);
+        result.mod = mod;
+        if (workshopAppId == null || !workshopAppId.matches("\\d+")) {
+            result.type = SearchResult.Type.API_ERROR;
+            result.setException(new Exception("Steam Workshop mod '" + mod.getName() + "' was found, but server-updater.software is not a numeric Steam app-id."));
+            return result;
+        }
+
+        try {
+            SteamCMD.SteamWorkshopItemDetails details = steamCMD.getWorkshopItemDetails(mod.getPublishedId());
+            result.latestVersion = details.getTimeUpdated();
+            result.downloadUrl = details.getFileUrl();
+            if (hasUpdate(mod, details.getTimeUpdated()))
+                result.type = SearchResult.Type.UPDATE_AVAILABLE;
+        } catch (Exception e) {
+            result.type = SearchResult.Type.API_ERROR;
+            result.setException(e);
+        }
+        return result;
+    }
+
+    boolean hasUpdate(SteamWorkshopMod mod, String latestVersion) {
+        if (latestVersion == null || latestVersion.isEmpty())
+            return false;
+        String currentVersion = mod.getVersion();
+        if (currentVersion == null || currentVersion.isEmpty())
+            return true;
+        if (latestVersion.equals(currentVersion))
+            return false;
+        if (currentVersion.equals(mod.getPublishedId()))
+            return true;
+        if (isSteamUnixTimestamp(latestVersion) && !isSteamUnixTimestamp(currentVersion))
+            return true;
+        try {
+            return Long.parseLong(latestVersion) > Long.parseLong(currentVersion);
+        } catch (NumberFormatException e) {
+            return true;
+        }
+    }
+
+    private boolean isSteamUnixTimestamp(String version) {
+        return version != null && version.matches("\\d{1,10}");
+    }
+}

--- a/src/main/java/com/osiris/autoplug/client/utils/SteamCMD.java
+++ b/src/main/java/com/osiris/autoplug/client/utils/SteamCMD.java
@@ -8,6 +8,9 @@
 
 package com.osiris.autoplug.client.utils;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.osiris.autoplug.client.configs.UpdaterConfig;
 import com.osiris.autoplug.client.tasks.updater.TaskDownload;
 import com.osiris.autoplug.client.utils.io.AsyncReader;
@@ -15,6 +18,11 @@ import com.osiris.autoplug.client.utils.terminal.AsyncTerminal;
 import com.osiris.betterthread.BThreadManager;
 import com.osiris.dyml.exceptions.*;
 import com.osiris.jlib.logger.AL;
+import okhttp3.FormBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 import org.rauschig.jarchivelib.ArchiveFormat;
 import org.rauschig.jarchivelib.Archiver;
 import org.rauschig.jarchivelib.ArchiverFactory;
@@ -35,6 +43,8 @@ import static com.osiris.jprocesses2.util.OS.isWindows;
 @SuppressWarnings({"WeakerAccess", "unused"})
 public class SteamCMD {
 
+    private static final String STEAM_WORKSHOP_DETAILS_URL = "https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/v1/";
+    private static final String STEAMCMD_WORKSHOP_COMMAND = "+login {LOGIN} +workshop_download_item {WORKSHOP_APP} {WORKSHOP_ITEM} validate +quit";
     private final String steamcmdArchive = "steamcmd" + (isWindows ? ".zip" : isMac ? "_osx.tar.gz" : "_linux.tar.gz");
     private final String steamcmdExtension = isWindows ? ".exe" : ".sh";
     private final String steamcmdExecutable = "steamcmd" + steamcmdExtension;
@@ -115,8 +125,7 @@ public class SteamCMD {
             AL.debug(this.getClass(), "Installing app " + appId + "...");
             onLog.accept("Installing app " + appId + "...");
 
-            String login = new UpdaterConfig().server_steamcmd_login.asString();
-            if (login == null || login.isEmpty()) login = "anonymous";
+            String login = getLogin();
 
             File gameInstallDir = new File(dirSteamServersDownloads + "/" + appId);
             gameInstallDir.mkdirs();
@@ -159,10 +168,140 @@ public class SteamCMD {
         }
     }
 
+    public boolean installOrUpdateWorkshopItem(String workshopAppId, String workshopItemId, Consumer<String> onLog, Consumer<String> onLogErr) {
+        try {
+            if (!installIfNeeded()) return false;
+            AL.debug(this.getClass(), "Installing workshop item " + workshopItemId + " for app " + workshopAppId + "...");
+            onLog.accept("Installing workshop item " + workshopItemId + "...");
+
+            AtomicBoolean isFinished = new AtomicBoolean(false);
+            AtomicBoolean isSuccess = new AtomicBoolean(true);
+            AsyncTerminal terminal = new AsyncTerminal(destDir, line -> {
+                onLog.accept(line);
+                String lowerLine = line.toLowerCase();
+                if (lowerLine.startsWith("success.") && lowerLine.contains("item " + workshopItemId.toLowerCase()))
+                    isFinished.set(true);
+                if (lowerLine.startsWith("error!")) {
+                    isSuccess.set(false);
+                    isFinished.set(true);
+                }
+            }, onLogErr, destExe.getAbsolutePath() + " " + buildWorkshopItemCommand(getLogin(), workshopAppId, workshopItemId));
+
+            Thread thread = new Thread(() -> terminal.process.destroy());
+            Runtime.getRuntime().addShutdownHook(thread);
+            while (!isFinished.get() && terminal.process.isAlive()) Thread.sleep(100);
+            if (terminal.process.isAlive()) terminal.process.destroy();
+            Runtime.getRuntime().removeShutdownHook(thread);
+            return isSuccess.get() && getWorkshopItemDir(workshopAppId, workshopItemId).exists();
+        } catch (Exception e) {
+            AL.warn(e);
+            return false;
+        }
+    }
+
+    public SteamWorkshopItemDetails getWorkshopItemDetails(String workshopItemId) throws IOException {
+        Request request = new Request.Builder()
+                .url(STEAM_WORKSHOP_DETAILS_URL)
+                .post(new FormBody.Builder()
+                        .add("itemcount", "1")
+                        .add("publishedfileids[0]", workshopItemId)
+                        .build())
+                .header("User-Agent", "AutoPlug-Client - https://autoplug.one")
+                .build();
+
+        Response response = new OkHttpClient().newCall(request).execute();
+        ResponseBody body = null;
+        try {
+            if (response.code() != 200)
+                throw new IOException("Steam Workshop details request failed for item " + workshopItemId + " with code " + response.code() + " message: " + response.message());
+
+            body = response.body();
+            if (body == null)
+                throw new IOException("Steam Workshop details request returned no body for item " + workshopItemId);
+
+            JsonObject root = JsonParser.parseString(body.string()).getAsJsonObject();
+            JsonObject responseObject = root.getAsJsonObject("response");
+            JsonArray details = responseObject == null ? null : responseObject.getAsJsonArray("publishedfiledetails");
+            if (details == null || details.size() == 0)
+                throw new IOException("Steam Workshop details request returned no details for item " + workshopItemId);
+
+            JsonObject detail = details.get(0).getAsJsonObject();
+            int result = detail.has("result") ? detail.get("result").getAsInt() : 0;
+            if (result != 1)
+                throw new IOException("Steam Workshop details request failed for item " + workshopItemId + " with result " + result);
+
+            String timeUpdated = getString(detail, "time_updated");
+            if (timeUpdated == null || timeUpdated.isEmpty())
+                throw new IOException("Steam Workshop details for item " + workshopItemId + " did not contain time_updated.");
+
+            return new SteamWorkshopItemDetails(
+                    getString(detail, "publishedfileid"),
+                    getString(detail, "title"),
+                    timeUpdated,
+                    getString(detail, "file_url"));
+        } finally {
+            if (body != null) body.close();
+            response.close();
+        }
+    }
+
+    public File getWorkshopItemDir(String workshopAppId, String workshopItemId) {
+        return new File(destDir + "/steamapps/workshop/content/" + workshopAppId + "/" + workshopItemId);
+    }
+
+    static String buildWorkshopItemCommand(String login, String workshopAppId, String workshopItemId) {
+        return STEAMCMD_WORKSHOP_COMMAND
+                .replace("{LOGIN}", login)
+                .replace("{WORKSHOP_APP}", workshopAppId)
+                .replace("{WORKSHOP_ITEM}", workshopItemId);
+    }
+
+    private String getLogin() throws NotLoadedException, YamlReaderException, YamlWriterException, IOException, IllegalKeyException, DuplicateKeyException, IllegalListException {
+        String login = new UpdaterConfig().server_steamcmd_login.asString();
+        if (login == null || login.isEmpty()) login = "anonymous";
+        return login;
+    }
+
+    private static String getString(JsonObject object, String key) {
+        if (object == null || !object.has(key) || object.get(key).isJsonNull())
+            return null;
+        return object.get(key).getAsString();
+    }
+
     public String getResolutionForError(String error) {
         for (Map.Entry<String, String> entry : errorResolutions.entrySet())
             if (error.contains(entry.getKey())) return entry.getValue();
         return "Unknown. :(";
+    }
+
+    public static class SteamWorkshopItemDetails {
+        private final String publishedFileId;
+        private final String title;
+        private final String timeUpdated;
+        private final String fileUrl;
+
+        public SteamWorkshopItemDetails(String publishedFileId, String title, String timeUpdated, String fileUrl) {
+            this.publishedFileId = publishedFileId;
+            this.title = title;
+            this.timeUpdated = timeUpdated;
+            this.fileUrl = fileUrl;
+        }
+
+        public String getPublishedFileId() {
+            return publishedFileId;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public String getTimeUpdated() {
+            return timeUpdated;
+        }
+
+        public String getFileUrl() {
+            return fileUrl;
+        }
     }
 
 }

--- a/src/test/java/com/osiris/autoplug/client/tasks/updater/mods/SteamWorkshopModTest.java
+++ b/src/test/java/com/osiris/autoplug/client/tasks/updater/mods/SteamWorkshopModTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024 Osiris-Team.
+ * All rights reserved.
+ *
+ * This software is copyrighted work, licensed under the terms
+ * of the MIT-License. Consult the "LICENSE" file for details.
+ */
+
+package com.osiris.autoplug.client.tasks.updater.mods;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SteamWorkshopModTest {
+
+    @TempDir
+    File tempDir;
+
+    @Test
+    void readsSteamWorkshopMetaCpp() throws Exception {
+        File modDir = new File(tempDir, "@CF");
+        modDir.mkdirs();
+        Files.write(new File(modDir, "meta.cpp").toPath(), (
+                "protocol = 1;\n" +
+                        "publishedid = 1559212036;\n" +
+                        "name = \"CF\";\n" +
+                        "timestamp = 5249804932187309401;\n"
+        ).getBytes(StandardCharsets.UTF_8));
+
+        SteamWorkshopMod mod = SteamWorkshopMod.readFromMeta(modDir, new File(modDir, "meta.cpp"));
+
+        assertEquals("CF", mod.getName());
+        assertEquals("1559212036", mod.getPublishedId());
+        assertEquals("5249804932187309401", mod.getVersion());
+        assertEquals("SteamWorkshop", mod.getAuthor());
+        assertEquals(modDir.getAbsolutePath(), mod.installationPath);
+    }
+
+    @Test
+    void findsWorkshopFoldersWithMetaCppOnly() throws Exception {
+        File first = new File(tempDir, "@First");
+        File second = new File(tempDir, "@Second");
+        File ignored = new File(tempDir, "@Ignored");
+        first.mkdirs();
+        second.mkdirs();
+        ignored.mkdirs();
+        Files.write(new File(first, "meta.cpp").toPath(), "publishedid = 1;\nname = \"First\";\n".getBytes(StandardCharsets.UTF_8));
+        Files.write(new File(second, "meta.cpp").toPath(), "publishedid = 2;\nname = \"Second\";\n".getBytes(StandardCharsets.UTF_8));
+
+        List<SteamWorkshopMod> mods = SteamWorkshopMod.findIn(tempDir);
+
+        assertEquals(2, mods.size());
+        assertEquals("First", mods.get(0).getName());
+        assertEquals("Second", mods.get(1).getName());
+    }
+}

--- a/src/test/java/com/osiris/autoplug/client/tasks/updater/mods/TaskSteamWorkshopModDownloadTest.java
+++ b/src/test/java/com/osiris/autoplug/client/tasks/updater/mods/TaskSteamWorkshopModDownloadTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024 Osiris-Team.
+ * All rights reserved.
+ *
+ * This software is copyrighted work, licensed under the terms
+ * of the MIT-License. Consult the "LICENSE" file for details.
+ */
+
+package com.osiris.autoplug.client.tasks.updater.mods;
+
+import com.osiris.autoplug.client.UtilsTest;
+import com.osiris.autoplug.client.tasks.updater.search.SearchResult;
+import com.osiris.autoplug.client.utils.SteamCMD;
+import com.osiris.betterthread.BThreadManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TaskSteamWorkshopModDownloadTest {
+
+    @TempDir
+    File tempDir;
+
+    @Test
+    void automaticProfileDownloadsAndInstallsWorkshopDirectory() throws Exception {
+        UtilsTest.init();
+        File installedDir = new File(tempDir, "@CF");
+        installedDir.mkdirs();
+        SteamWorkshopMod mod = new SteamWorkshopMod(installedDir, "CF", "1559212036", "100");
+        SearchResult result = new SearchResult(null, SearchResult.Type.UPDATE_AVAILABLE, "200", null, "steam-workshop", null, null, false);
+        result.mod = mod;
+        FakeSteamCMD steamCMD = new FakeSteamCMD(tempDir);
+
+        TaskSteamWorkshopModDownload task = new TaskSteamWorkshopModDownload(
+                "SteamWorkshopModDownloader", new BThreadManager(), mod, "221100", "AUTOMATIC", steamCMD, result);
+        task.runAtStart();
+
+        assertTrue(task.isDownloadSuccessful());
+        assertTrue(task.isInstallSuccessful());
+        assertTrue(new File(installedDir, "updated.txt").exists());
+        assertEquals(result, task.getSearchResult());
+    }
+
+    private static class FakeSteamCMD extends SteamCMD {
+        private final File root;
+
+        private FakeSteamCMD(File root) {
+            this.root = root;
+            this.destDir = new File(root, "steamcmd");
+        }
+
+        @Override
+        public boolean installOrUpdateWorkshopItem(String workshopAppId, String workshopItemId, Consumer<String> onLog, Consumer<String> onLogErr) {
+            try {
+                File downloaded = getWorkshopItemDir(workshopAppId, workshopItemId);
+                downloaded.mkdirs();
+                Files.write(new File(downloaded, "updated.txt").toPath(), "updated".getBytes(StandardCharsets.UTF_8));
+                onLog.accept("Success. Downloaded item " + workshopItemId);
+                return true;
+            } catch (Exception e) {
+                onLogErr.accept(e.getMessage());
+                return false;
+            }
+        }
+    }
+}

--- a/src/test/java/com/osiris/autoplug/client/tasks/updater/search/SteamWorkshopSearchTest.java
+++ b/src/test/java/com/osiris/autoplug/client/tasks/updater/search/SteamWorkshopSearchTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2024 Osiris-Team.
+ * All rights reserved.
+ *
+ * This software is copyrighted work, licensed under the terms
+ * of the MIT-License. Consult the "LICENSE" file for details.
+ */
+
+package com.osiris.autoplug.client.tasks.updater.search;
+
+import com.osiris.autoplug.client.tasks.updater.mods.SteamWorkshopMod;
+import com.osiris.autoplug.client.utils.SteamCMD;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SteamWorkshopSearchTest {
+
+    @TempDir
+    File tempDir;
+
+    @Test
+    void returnsUpdateAvailableWhenSteamTimestampIsNewer() {
+        SteamWorkshopMod mod = new SteamWorkshopMod(tempDir, "CF", "1559212036", "100");
+        SteamWorkshopSearch search = new SteamWorkshopSearch();
+
+        SearchResult result = search.search(mod, "221100", new FakeSteamCMD("200"));
+
+        assertEquals(SearchResult.Type.UPDATE_AVAILABLE, result.type);
+        assertEquals("200", result.getLatestVersion());
+        assertEquals("steam-workshop", result.getDownloadType());
+        assertEquals(mod, result.mod);
+    }
+
+    @Test
+    void treatsMetaCppTimestampAsStaleWhenSteamReturnsUnixTime() {
+        SteamWorkshopMod mod = new SteamWorkshopMod(tempDir, "CF", "1559212036", "5249804932187309401");
+        SteamWorkshopSearch search = new SteamWorkshopSearch();
+
+        SearchResult result = search.search(mod, "221100", new FakeSteamCMD("1715700000"));
+
+        assertEquals(SearchResult.Type.UPDATE_AVAILABLE, result.type);
+    }
+
+    @Test
+    void returnsUpToDateWhenSteamTimestampMatches() {
+        SteamWorkshopMod mod = new SteamWorkshopMod(tempDir, "CF", "1559212036", "200");
+        SteamWorkshopSearch search = new SteamWorkshopSearch();
+
+        SearchResult result = search.search(mod, "221100", new FakeSteamCMD("200"));
+
+        assertEquals(SearchResult.Type.UP_TO_DATE, result.type);
+    }
+
+    @Test
+    void rejectsNonNumericSteamAppId() {
+        SteamWorkshopMod mod = new SteamWorkshopMod(tempDir, "CF", "1559212036", "100");
+        SteamWorkshopSearch search = new SteamWorkshopSearch();
+
+        SearchResult result = search.search(mod, "paper", new FakeSteamCMD("200"));
+
+        assertEquals(SearchResult.Type.API_ERROR, result.type);
+    }
+
+    private static class FakeSteamCMD extends SteamCMD {
+        private final String timeUpdated;
+
+        private FakeSteamCMD(String timeUpdated) {
+            this.timeUpdated = timeUpdated;
+        }
+
+        @Override
+        public SteamWorkshopItemDetails getWorkshopItemDetails(String workshopItemId) throws IOException {
+            return new SteamWorkshopItemDetails(workshopItemId, "CF", timeUpdated, null);
+        }
+    }
+}

--- a/src/test/java/com/osiris/autoplug/client/utils/SteamCMDTest.java
+++ b/src/test/java/com/osiris/autoplug/client/utils/SteamCMDTest.java
@@ -20,4 +20,13 @@ class SteamCMDTest {
         UtilsTest.init();
         new SteamCMD().installIfNeeded();
     }
+
+    @Test
+    void buildsWorkshopDownloadCommand() {
+        String command = SteamCMD.buildWorkshopItemCommand("anonymous", "221100", "1559212036");
+
+        org.junit.jupiter.api.Assertions.assertEquals(
+                "+login anonymous +workshop_download_item 221100 1559212036 validate +quit",
+                command);
+    }
 }


### PR DESCRIPTION
Fixes #215.

This adds generic Steam Workshop mod update support for mod folders that contain `meta.cpp` with `publishedid`. The implementation keeps the Steam Workshop search path behind `ResourceFinder`, reuses the existing `server-updater.software` numeric Steam app id, and downloads workshop items through SteamCMD before installing them through a mod download task.

Scope:
- detects Steam Workshop mod directories from `meta.cpp`
- caches `steam-workshop-id`, current `version`, and `latest-version` in `mods.yml`
- checks Steam Workshop `time_updated` before downloading
- supports NOTIFY, MANUAL, and AUTOMATIC profiles
- adds parser, search, SteamCMD command, and fake-SteamCMD install tests

Validation:
- `mvn -q -DskipTests compile`
- `mvn -q -Dtest=SteamWorkshopModTest,SteamWorkshopSearchTest,TaskSteamWorkshopModDownloadTest,SteamCMDTest#buildsWorkshopDownloadCommand test`
- `git diff --check`

No payout details are posted publicly.