### PR TITLE
Ptero support

### DIFF
--- a/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
+++ b/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
@@ -120,6 +120,7 @@ public class UpdaterConfig extends MyYaml {
                 "AutoPlug is able to update itself automatically.",
                 "Its strongly recommended to have this feature enabled,",
                 "to benefit from new features, bug fixes and security enhancements.",
+                "Pterodactyl-managed servers disable this at runtime to avoid restart loops.",
                 "Linux users, using screen read this: https://github.com/Osiris-Team/AutoPlug-Client/issues/75");
         self_updater_profile = put(name, "self-updater", "profile").setDefValues("AUTOMATIC");
         self_updater_build = put(name, "self-updater", "build").setDefValues("stable").setComments(

--- a/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
+++ b/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
@@ -28,6 +28,7 @@ public class UpdaterConfig extends MyYaml {
     public YamlSection self_updater;
     public YamlSection self_updater_profile;
     public YamlSection self_updater_build;
+    public YamlSection self_updater_safe_mode;
 
     public YamlSection java_updater;
     public YamlSection java_updater_profile;
@@ -126,6 +127,10 @@ public class UpdaterConfig extends MyYaml {
         self_updater_build = put(name, "self-updater", "build").setDefValues("stable").setComments(
                 "Choose between 'stable' and 'beta' builds.",
                 "Stable builds are recommended.");
+        self_updater_safe_mode = put(name, "self-updater", "safe-mode").setDefValues("true").setComments(
+                "If AutoPlug is disabled, it will update itself without advanced compatibility. Self-updating on Ptero will work in the same way as it does when not on Ptero.",
+                "Its strongly recommended to have this feature enabled on non AutoPlug specific eggs,"
+        );
 
         put(name, "java-updater").setCountTopLineBreaks(1);
         java_updater = put(name, "java-updater", "enable").setDefValues("true");

--- a/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
+++ b/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
@@ -122,7 +122,6 @@ public class UpdaterConfig extends MyYaml {
                 "AutoPlug is able to update itself automatically.",
                 "Its strongly recommended to have this feature enabled,",
                 "to benefit from new features, bug fixes and security enhancements.",
-                "Pterodactyl-managed servers disable this at runtime to avoid restart loops.",
                 "Linux users, using screen read this: https://github.com/Osiris-Team/AutoPlug-Client/issues/75");
         self_updater_profile = put(name, "self-updater", "profile").setDefValues("AUTOMATIC");
         self_updater_build = put(name, "self-updater", "build").setDefValues("stable").setComments(

--- a/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
+++ b/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
@@ -17,7 +17,6 @@ import com.osiris.jlib.logger.AL;
 import io.github.projectunified.mcserverupdater.UpdateBuilder;
 
 import java.io.IOException;
-import java.util.stream.Collectors;
 
 public class UpdaterConfig extends MyYaml {
 
@@ -28,7 +27,6 @@ public class UpdaterConfig extends MyYaml {
     public YamlSection self_updater;
     public YamlSection self_updater_profile;
     public YamlSection self_updater_build;
-    public YamlSection self_updater_safe_mode;
 
     public YamlSection java_updater;
     public YamlSection java_updater_profile;
@@ -127,10 +125,6 @@ public class UpdaterConfig extends MyYaml {
         self_updater_build = put(name, "self-updater", "build").setDefValues("stable").setComments(
                 "Choose between 'stable' and 'beta' builds.",
                 "Stable builds are recommended.");
-        self_updater_safe_mode = put(name, "self-updater", "safe-mode").setDefValues("true").setComments(
-                "If AutoPlug is disabled, it will update itself without advanced compatibility. Self-updating on Ptero will work in the same way as it does when not on Ptero.",
-                "Its strongly recommended to have this feature enabled on non AutoPlug specific eggs,"
-        );
 
         put(name, "java-updater").setCountTopLineBreaks(1);
         java_updater = put(name, "java-updater", "enable").setDefValues("true");

--- a/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
+++ b/src/main/java/com/osiris/autoplug/client/configs/UpdaterConfig.java
@@ -36,6 +36,7 @@ public class UpdaterConfig extends MyYaml {
     public YamlSection java_updater_version;
     public YamlSection java_updater_build_id;
     public YamlSection java_updater_large_heap;
+    public YamlSection java_updater_force_enable;
 
     public YamlSection server_updater;
     public YamlSection server_updater_profile;
@@ -147,6 +148,9 @@ public class UpdaterConfig extends MyYaml {
                 "Otherwise don't touch this. It gets replaced after every successful update automatically.");
         java_updater_large_heap = put(name, "java-updater", "large-heap").setDefValues("false").setComments(
                 "Only enable if you plan to give your server more than 57gb of ram, otherwise not recommended.");
+        java_updater_force_enable = put(name, "java-updater", "force-enable").setDefValues("false").setComments(
+                "If you are running AutoPlug via Pterodactyl Panel, the java-updater is disabled to avoid redundancy. Set to true to force the self-updater to run anyways."
+        );
 
 
         put(name, "server-updater").setCountTopLineBreaks(1);

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/TaskDownload.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/TaskDownload.java
@@ -22,6 +22,7 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Random;
 
 public class TaskDownload extends BThread {
@@ -76,18 +77,8 @@ public class TaskDownload extends BThread {
             body = response.body();
             if (body == null)
                 throw new Exception("Download of '" + dest.getName() + "' failed because of null response body!");
-            else if (!ignoreContentType && body.contentType() == null)
-                throw new Exception("Download of '" + dest.getName() + "' failed due to null content type!");
-            else if (!ignoreContentType && !body.contentType().type().equals("application"))
-                throw new Exception("Download of '" + dest.getName() + "' failed because of invalid content type: " + body.contentType().type());
-            else if (!ignoreContentType && !body.contentType().subtype().equals("java-archive")
-                    && !body.contentType().subtype().equals("jar")
-                    && !body.contentType().subtype().equals("octet-stream")) {
-                if (allowedSubContentTypes == null)
-                    throw new Exception("Download of '" + dest.getName() + "' failed because of invalid sub-content type: " + body.contentType().subtype());
-                if (!Arrays.asList(allowedSubContentTypes).contains(body.contentType().subtype()))
-                    throw new Exception("Download of '" + dest.getName() + "' failed because of invalid sub-content type: " + body.contentType().subtype());
-            }
+            if (!isAllowedContentType(fileName, body.contentType(), ignoreContentType, allowedSubContentTypes))
+                throw new Exception("Download of '" + dest.getName() + "' failed because of invalid content type: " + body.contentType());
 
             long completeFileSize = body.contentLength();
             setMax(completeFileSize);
@@ -149,6 +140,22 @@ public class TaskDownload extends BThread {
         AL.debug(this.getClass(), "Comparing hashes (SHA-256). Is equal? " +
                 result + " Excepted: \"" + expectedHash + "\" Actual: \"" + myHash + "\"");
         return result;
+    }
+
+    static boolean isAllowedContentType(String fileName, okhttp3.MediaType contentType, boolean ignoreContentType, String... allowedSubContentTypes) {
+        if (ignoreContentType) return true;
+        if (contentType == null) return false;
+        String type = contentType.type();
+        String subtype = contentType.subtype();
+        if ("application".equals(type)) {
+            if ("java-archive".equals(subtype) || "jar".equals(subtype) || "octet-stream".equals(subtype)) return true;
+            if (allowedSubContentTypes == null) return false;
+            return Arrays.asList(allowedSubContentTypes).contains(subtype);
+        }
+        return fileName != null
+                && fileName.toLowerCase(Locale.ROOT).endsWith(".jar")
+                && "text".equals(type)
+                && "plain".equals(subtype);
     }
 
 }

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/java/TaskJavaUpdater.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/java/TaskJavaUpdater.java
@@ -14,6 +14,7 @@ import com.google.gson.JsonObject;
 import com.osiris.autoplug.client.Server;
 import com.osiris.autoplug.client.configs.UpdaterConfig;
 import com.osiris.autoplug.client.utils.GD;
+import com.osiris.autoplug.client.utils.UtilsEnvironment;
 import com.osiris.betterthread.BThread;
 import com.osiris.betterthread.BThreadManager;
 import com.osiris.jlib.logger.AL;
@@ -42,6 +43,11 @@ public class TaskJavaUpdater extends BThread {
         super.runAtStart();
         updaterConfig = new UpdaterConfig();
         if (!updaterConfig.java_updater.asBoolean()) {
+            skip();
+            return;
+        }
+        if (new UtilsEnvironment().isPterodactylEnvironment()) {
+            setStatus("Java updater disabled on Pterodactyl-managed servers.");
             skip();
             return;
         }

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/java/TaskJavaUpdater.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/java/TaskJavaUpdater.java
@@ -46,17 +46,12 @@ public class TaskJavaUpdater extends BThread {
             skip();
             return;
         }
-        if (new UtilsEnvironment().isPterodactylEnvironment()) {
+        if (new UtilsEnvironment().isPterodactylEnvironment() && !updaterConfig.java_updater_force_enable.asBoolean()) {
             setStatus("Java updater disabled on Pterodactyl-managed servers.");
             skip();
             return;
         }
         if (Server.isRunning()) throw new Exception("Cannot perform update while server is running!");
-
-        if (!updaterConfig.java_updater.asBoolean()) {
-            skip();
-            return;
-        }
 
         setStatus("Searching for updates...");
 

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/self/TaskSelfUpdater.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/self/TaskSelfUpdater.java
@@ -51,11 +51,6 @@ public class TaskSelfUpdater extends BThread {
             skip();
             return;
         }
-        if (new UtilsEnvironment().isPterodactylEnvironment()) {
-            setStatus("Self-updater disabled on Pterodactyl-managed servers.");
-            skip();
-            return;
-        }
         if (Server.isRunning()) throw new Exception("Cannot perform self update while server is running!");
 
         if (updaterConfig.self_updater_build.asString().equals("stable"))
@@ -164,6 +159,18 @@ public class TaskSelfUpdater extends BThread {
                     setStatus("AutoPlug update downloaded. Checking hash...");
                     if (!download.compareWithSHA256(sha256)) {
                         finish("Downloaded AutoPlug update is broken. Nothing changed!", false);
+                        return;
+                    }
+                    boolean isPterodactyl = new UtilsEnvironment().isPterodactylEnvironment();
+                    if (isPterodactyl) {
+                        File currentJarFile = currentInstallationPath != null
+                                ? FileManager.convertRelativeToAbsolutePath(currentInstallationPath)
+                                : new UtilsJar().getThisJar();
+                        setStatus("Installing AutoPlug update in place (" + currentVersion + " -> " + version + ")...");
+                        Files.copy(cache_dest.toPath(), currentJarFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                        setStatus("AutoPlug update was installed successfully (" + currentVersion + " -> " + version + ")!");
+                        finish(true);
+                        System.exit(0);
                         return;
                     }
                     setStatus("Installing AutoPlug update (" + currentVersion + " -> " + version + ")...");

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/self/TaskSelfUpdater.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/self/TaskSelfUpdater.java
@@ -162,7 +162,7 @@ public class TaskSelfUpdater extends BThread {
                         return;
                     }
                     boolean isPterodactyl = new UtilsEnvironment().isPterodactylEnvironment();
-                    if (isPterodactyl && updaterConfig.self_updater_safe_mode.asBoolean()) {
+                    if (isPterodactyl) {
                         File currentJarFile = currentInstallationPath != null
                                 ? FileManager.convertRelativeToAbsolutePath(currentInstallationPath)
                                 : new UtilsJar().getThisJar();

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/self/TaskSelfUpdater.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/self/TaskSelfUpdater.java
@@ -162,7 +162,7 @@ public class TaskSelfUpdater extends BThread {
                         return;
                     }
                     boolean isPterodactyl = new UtilsEnvironment().isPterodactylEnvironment();
-                    if (isPterodactyl) {
+                    if (isPterodactyl && updaterConfig.self_updater_safe_mode.asBoolean()) {
                         File currentJarFile = currentInstallationPath != null
                                 ? FileManager.convertRelativeToAbsolutePath(currentInstallationPath)
                                 : new UtilsJar().getThisJar();

--- a/src/main/java/com/osiris/autoplug/client/tasks/updater/self/TaskSelfUpdater.java
+++ b/src/main/java/com/osiris/autoplug/client/tasks/updater/self/TaskSelfUpdater.java
@@ -15,6 +15,7 @@ import com.osiris.autoplug.client.configs.UpdaterConfig;
 import com.osiris.autoplug.client.managers.FileManager;
 import com.osiris.autoplug.client.tasks.updater.TaskDownload;
 import com.osiris.autoplug.client.utils.GD;
+import com.osiris.autoplug.client.utils.UtilsEnvironment;
 import com.osiris.autoplug.client.utils.UtilsJar;
 import com.osiris.betterthread.BThread;
 import com.osiris.betterthread.BThreadManager;
@@ -47,6 +48,11 @@ public class TaskSelfUpdater extends BThread {
         updaterConfig = new UpdaterConfig();
 
         if (!updaterConfig.self_updater.asBoolean()) {
+            skip();
+            return;
+        }
+        if (new UtilsEnvironment().isPterodactylEnvironment()) {
+            setStatus("Self-updater disabled on Pterodactyl-managed servers.");
             skip();
             return;
         }
@@ -180,5 +186,3 @@ public class TaskSelfUpdater extends BThread {
     }
 
 }
-
-

--- a/src/main/java/com/osiris/autoplug/client/utils/UtilsEnvironment.java
+++ b/src/main/java/com/osiris/autoplug/client/utils/UtilsEnvironment.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Osiris-Team.
+ * All rights reserved.
+ *
+ * This software is copyrighted work, licensed under the terms
+ * of the MIT-License. Consult the "LICENSE" file for details.
+ */
+
+package com.osiris.autoplug.client.utils;
+
+import java.util.Locale;
+import java.util.Map;
+
+public class UtilsEnvironment {
+    public boolean isPterodactylEnvironment() {
+        return isPterodactylEnvironment(System.getenv());
+    }
+
+    public boolean isPterodactylEnvironment(Map<String, String> env) {
+        for (String key : env.keySet()) {
+            if (key == null) continue;
+            String upperKey = key.toUpperCase(Locale.ROOT);
+            if (upperKey.startsWith("PTERODACTYL_")) return true;
+            if (upperKey.startsWith("P_SERVER_")) return true;
+        }
+        return false;
+    }
+}

--- a/src/test/java/com/osiris/autoplug/client/utils/UtilsEnvironmentTest.java
+++ b/src/test/java/com/osiris/autoplug/client/utils/UtilsEnvironmentTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Osiris-Team.
+ * All rights reserved.
+ *
+ * This software is copyrighted work, licensed under the terms
+ * of the MIT-License. Consult the "LICENSE" file for details.
+ */
+
+package com.osiris.autoplug.client.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UtilsEnvironmentTest {
+    @Test
+    void detectsPterodactylEnvVars() {
+        UtilsEnvironment utilsEnvironment = new UtilsEnvironment();
+
+        Map<String, String> env = new HashMap<>();
+        env.put("P_SERVER_UUID", "abc");
+        assertTrue(utilsEnvironment.isPterodactylEnvironment(env));
+
+        env.clear();
+        env.put("PTERODACTYL_SERVER_UUID", "abc");
+        assertTrue(utilsEnvironment.isPterodactylEnvironment(env));
+    }
+
+    @Test
+    void ignoresNonPterodactylEnvVars() {
+        UtilsEnvironment utilsEnvironment = new UtilsEnvironment();
+
+        Map<String, String> env = new HashMap<>();
+        env.put("SERVER_UUID", "abc");
+        env.put("PANEL_NAME", "AutoPlug");
+        assertFalse(utilsEnvironment.isPterodactylEnvironment(env));
+    }
+}


### PR DESCRIPTION
- Makes Self Updater work fine with Ptero Setups
- Disable Java update on Ptero
- Download validation was improved because else it failed because of that
- New ``self-updater.safe-mode`` config option, if disabled it skips the special handling. 

Closes #287.

Ptero detection could be improved. Was just generated by GitHub Copilot and worked fine. 